### PR TITLE
Prevent Land owner deletion

### DIFF
--- a/projects/tera/api/src/Entity/LandMember.php
+++ b/projects/tera/api/src/Entity/LandMember.php
@@ -28,7 +28,7 @@ use Symfony\Component\Uid\Ulid;
     denormalizationContext: ['groups' => ['user:land_member:patch']],
     security: "is_granted('" . LandMemberPermission::UPDATE . "', object)")
 ]
-#[Delete(security: "is_granted('" . LandMemberPermission::DELETE . "', object) or object.getPerson() == user")]
+#[Delete(security: "(is_granted('" . LandMemberPermission::DELETE . "', object) or object.getPerson() == user) and !object.isOwner()")]
 #[Get(normalizationContext: ['groups' => ['user:land_member:get']], security: "is_granted('" . LandMemberPermission::READ . "', object) or object.getPerson() == user")]
 #[GetCollection(
     normalizationContext: ['groups' => ['user:land_member:collection']],

--- a/projects/tera/api/tests/Functional/Land/LandMemberTest.php
+++ b/projects/tera/api/tests/Functional/Land/LandMemberTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Land;
 
+use App\Repository\LandMemberRepository;
 use App\Security\Constant\LandMemberPermission;
 use App\Tests\Utils\Abstract\AbstractApiTestCase;
 use Zenstruck\Browser\Json;
@@ -134,7 +135,7 @@ class LandMemberTest extends AbstractApiTestCase
     public function testDelete()
     {
         $context = $this->createLandContext();
-        $this->addLandMember($context);
+        $context = $this->addLandMember($context);
 
         // Owner
         $this->browser()->actingAs($context->owner)
@@ -157,5 +158,17 @@ class LandMemberTest extends AbstractApiTestCase
         $this->browser()->actingAs($context->landMembers[3]->getPerson())
             ->delete($this->getIriFromResource($context->landMembers[3]))
             ->assertStatus(204);
+    }
+
+    public function testCantDeleteOwner()
+    {
+        $context = $this->createLandContext();
+
+        $landMemberRepository = static::getContainer()->get(LandMemberRepository::class);
+        $landMember = $landMemberRepository->findOneBy(['person' => $context->owner->_real(), 'land' => $context->land->_real()]);
+
+        $this->browser()->actingAs($context->owner)
+            ->delete($this->getIriFromResource($landMember))
+            ->assertStatus(403);
     }
 }

--- a/projects/tera/app/src/pages/land/settings/PageLandSettingsTeam.vue
+++ b/projects/tera/app/src/pages/land/settings/PageLandSettingsTeam.vue
@@ -7,8 +7,12 @@
       v-if="landMembers?.member && land"
       class="flex flex-col gap-4"
     >
+      <CardTeraLandMember
+        :land-member="landMembers.member.filter((item) => item.owner)[0]!"
+        :hoverable="false"
+      />
       <DialogTeraLandMemberUpdate
-        v-for="(item, index) in landMembers.member"
+        v-for="(item, index) in landMembers.member.filter((item) => !item.owner)"
         :key="index"
         :land-member="item"
         :land="land"

--- a/projects/tera/app/src/pages/land/settings/PageLandSettingsTeam.vue
+++ b/projects/tera/app/src/pages/land/settings/PageLandSettingsTeam.vue
@@ -8,7 +8,8 @@
       class="flex flex-col gap-4"
     >
       <CardTeraLandMember
-        :land-member="landMembers.member.filter((item) => item.owner)[0]!"
+        v-if="owner"
+        :land-member="owner"
         :hoverable="false"
       />
       <DialogTeraLandMemberUpdate
@@ -251,6 +252,13 @@ const { data: landMembers, refetch: refetchLandMembers } = useQuery({
     return response.data;
   },
   enabled,
+});
+
+const owner = computed(() => {
+  if (landMembers.value) {
+    return landMembers.value.member.find((item) => item.owner);
+  }
+  return null;
 });
 
 const { on: onLandMemberPatch } = useEventBus(landMemberPatchSucceededEvent);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a computed property to display the first land member that is an owner.
  - Enhanced the existing component to filter out owner members, ensuring clarity in the rendering of land members.

- **Bug Fixes**
  - Updated deletion controls to enhance security by preventing users from deleting resources they own, ensuring actions align with expected permissions.

- **Tests**
  - Added a new test case to verify that an owner cannot delete their own membership, enhancing the test suite for deletion restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->