### PR TITLE
Allow person to accept/refuse land invitation

### DIFF
--- a/libs/tera/ui-components/land-member-invitation/badge/BadgeTeraLandMemberInvitation.vue
+++ b/libs/tera/ui-components/land-member-invitation/badge/BadgeTeraLandMemberInvitation.vue
@@ -10,14 +10,14 @@
 <script setup lang="ts">
 import { useI18nExtended } from '@lychen/vue-i18n-util-composables/useI18nExtended';
 import { messages, TRANSLATION_KEY } from '@lychen/tera-ui-i18n/land-member-invitation';
-import { LandMemberInvitationState } from '@lychen/tera-util-api-sdk/generated/tera-api';
+import { PathsApiLand_member_invitationsBy_emailGetParametersQueryState as State } from '@lychen/tera-util-api-sdk/generated/tera-api';
 
 const { t } = useI18nExtended({ messages, rootKey: TRANSLATION_KEY, prefixed: true });
-defineProps<{ state: LandMemberInvitationState }>();
+defineProps<{ state: State }>();
 
 const classes = {
-  [LandMemberInvitationState.pending]: 'bg-surface-container-high text-on-surface-container-high',
-  [LandMemberInvitationState.refused]: 'bg-negative text-on-negative',
-  [LandMemberInvitationState.accepted]: 'bg-positive text-on-positive',
+  [State.pending]: 'bg-surface-container-high text-on-surface-container-high',
+  [State.refused]: 'bg-negative text-on-negative',
+  [State.accepted]: 'bg-positive text-on-positive',
 };
 </script>

--- a/libs/tera/ui-components/land-member-invitation/card/CardTeraLandMemberInvitation.vue
+++ b/libs/tera/ui-components/land-member-invitation/card/CardTeraLandMemberInvitation.vue
@@ -153,7 +153,9 @@ const { mutate: refuse } = useMutation({
       throw new Error('missing.ulid');
     }
     const response = await api.PATCH('/api/land_member_invitations/{ulid}/refuse', {
-      params: { path: { ulid: landMemberInvitation.ulid } },
+      params: {
+        path: { ulid: landMemberInvitation.ulid },
+      },
       body: {},
     });
 

--- a/libs/tera/ui-components/land-member-invitation/card/CardTeraLandMemberInvitation.vue
+++ b/libs/tera/ui-components/land-member-invitation/card/CardTeraLandMemberInvitation.vue
@@ -4,7 +4,26 @@
     hoverable
   >
     <div class="flex flex-col gap-1">
-      <p class="font-medium">{{ landMemberInvitation.email }}</p>
+      <p
+        v-if="landMemberInvitation.email"
+        class="font-medium"
+      >
+        {{ landMemberInvitation.email }}
+      </p>
+      <template v-if="variant === VARIANT.ForUser">
+        <small class="opacity-80">{{ t('invite_sentence.prefix') }}</small>
+        <BaseHeading
+          v-if="land"
+          variant="h3"
+          >{{ land.name }}</BaseHeading
+        >
+        <small
+          v-if="variant === VARIANT.ForUser"
+          class="opacity-80"
+          >{{ t('invite_sentence.suffix') }}
+        </small>
+      </template>
+
       <div
         v-if="landRoles"
         class="flex flex-row gap-2"
@@ -21,7 +40,10 @@
       :state="landMemberInvitation.state"
     />
     <div class="flex flex-row gap-2">
-      <DialogTeraLandMemberInvitationDelete :land-member-invitation="landMemberInvitation">
+      <DialogTeraLandMemberInvitationDelete
+        v-if="variant === VARIANT.Settings && landMemberInvitation"
+        :land-member-invitation="landMemberInvitation"
+      >
         <Button
           :icon="faTrash"
           variant="negative"
@@ -33,11 +55,13 @@
         <Button
           :icon="faCheck"
           variant="positive"
-          size="sm" />
+          size="sm"
+          @click="accept" />
         <Button
           :icon="faTimes"
           variant="negative"
           size="sm"
+          @click="refuse"
       /></template>
     </div>
   </Card>
@@ -54,13 +78,100 @@ import { faTimes } from '@fortawesome/pro-light-svg-icons/faTimes';
 import { VARIANT, type Variant } from '.';
 import BadgeTeraLandMemberInvitation from '../badge/BadgeTeraLandMemberInvitation.vue';
 import type { components } from '@lychen/tera-util-api-sdk/generated/tera-api';
+import { defineAsyncComponent } from 'vue';
+import { useI18nExtended } from '@lychen/vue-i18n-util-composables/useI18nExtended';
+import { TRANSLATION_KEY, messages } from './i18n';
+import {
+  TRANSLATION_KEY as LAND_MEMBER_INVITATION_TRANSLATION_KEY,
+  messages as messagesLandMemberInvitations,
+} from '@lychen/tera-ui-i18n/land-member-invitation';
+import { useMutation } from '@tanstack/vue-query';
+import { useTeraApi } from '@lychen/tera-util-api-sdk/composables/useTeraApi';
+import { toast } from '@lychen/vue-ui-components-core/toast';
+import {
+  landMemberInvitationAcceptSucceededEvent,
+  landMemberInvitationRefuseSucceededEvent,
+} from '@lychen/tera-util-events/LandMemberInvitationEvents';
+import { useEventBus } from '@vueuse/core';
 
-const { variant = VARIANT.Settings } = defineProps<{
+const BaseHeading = defineAsyncComponent(
+  () => import('@lychen/vue-ui-components-app/base-heading/BaseHeading.vue'),
+);
+
+const { variant = VARIANT.Settings, landMemberInvitation } = defineProps<{
   variant?: Variant;
-  landMemberInvitation: Pick<
-    components['schemas']['LandMemberInvitation.jsonld'],
-    'email' | 'state'
+  landMemberInvitation: Partial<
+    Pick<components['schemas']['LandMemberInvitation.jsonld'], 'email' | 'state' | 'ulid'>
   >;
   landRoles?: Pick<components['schemas']['LandRole.jsonld'], 'name'>[];
+  land?: Pick<components['schemas']['Land.jsonld'], 'name'>;
 }>();
+
+const { t } = useI18nExtended({ messages, rootKey: TRANSLATION_KEY, prefixed: true });
+
+const { t: tLandMemberInvitation } = useI18nExtended({
+  messages: messagesLandMemberInvitations,
+  rootKey: LAND_MEMBER_INVITATION_TRANSLATION_KEY,
+  prefixed: true,
+});
+
+const { api } = useTeraApi();
+const { emit: emitAccept } = useEventBus(landMemberInvitationAcceptSucceededEvent);
+
+const { mutate: accept } = useMutation({
+  mutationFn: async () => {
+    if (!landMemberInvitation.ulid) {
+      throw new Error('missing.ulid');
+    }
+    const response = await api.PATCH('/api/land_member_invitations/{ulid}/accept', {
+      params: { path: { ulid: landMemberInvitation.ulid } },
+      body: {},
+    });
+
+    return response.data;
+  },
+  onSuccess: (data, variables, context) => {
+    toast({
+      title: tLandMemberInvitation('action.accept.success.message'),
+      variant: 'positive',
+    });
+    emitAccept(data);
+  },
+  onError: (error, variables, context) => {
+    toast({
+      title: tLandMemberInvitation('action.accept.error.message'),
+      description: error.message,
+      variant: 'negative',
+    });
+  },
+});
+
+const { emit: emitRefuse } = useEventBus(landMemberInvitationRefuseSucceededEvent);
+const { mutate: refuse } = useMutation({
+  mutationFn: async () => {
+    if (!landMemberInvitation.ulid) {
+      throw new Error('missing.ulid');
+    }
+    const response = await api.PATCH('/api/land_member_invitations/{ulid}/refuse', {
+      params: { path: { ulid: landMemberInvitation.ulid } },
+      body: {},
+    });
+
+    return response.data;
+  },
+  onSuccess: (data, variables, context) => {
+    toast({
+      title: tLandMemberInvitation('action.refuse.success.message'),
+      variant: 'positive',
+    });
+    emitRefuse(data);
+  },
+  onError: (error, variables, context) => {
+    toast({
+      title: tLandMemberInvitation('action.refuse.error.message'),
+      description: error.message,
+      variant: 'negative',
+    });
+  },
+});
 </script>

--- a/libs/tera/ui-components/land-member-invitation/card/i18n/en-US.ts
+++ b/libs/tera/ui-components/land-member-invitation/card/i18n/en-US.ts
@@ -1,0 +1,6 @@
+export default {
+  invite_sentence: {
+    prefix: 'You are invited to join',
+    suffix: 'as',
+  },
+};

--- a/libs/tera/ui-components/land-member-invitation/card/i18n/fr-FR.ts
+++ b/libs/tera/ui-components/land-member-invitation/card/i18n/fr-FR.ts
@@ -1,0 +1,6 @@
+export default {
+  invite_sentence: {
+    prefix: 'Vous êtes invité·e à rejoindre',
+    suffix: 'en tant que',
+  },
+};

--- a/libs/tera/ui-components/land-member-invitation/card/i18n/index.ts
+++ b/libs/tera/ui-components/land-member-invitation/card/i18n/index.ts
@@ -1,0 +1,10 @@
+import enUs from './en-US';
+import frFr from './fr-FR';
+
+export const messages = {
+  'fr-FR': frFr,
+  'en-US': enUs,
+  'en-GB': enUs,
+};
+
+export const TRANSLATION_KEY = 'card_tera_land_member_invitation';

--- a/libs/tera/ui-components/land-member-invitation/dialogs/delete/DialogTeraLandMemberInvitationDelete.vue
+++ b/libs/tera/ui-components/land-member-invitation/dialogs/delete/DialogTeraLandMemberInvitationDelete.vue
@@ -54,7 +54,7 @@ const { t: t } = useI18nExtended({
 const { emit } = useEventBus(landMemberInvitationDeleteSucceededEvent);
 
 const { landMemberInvitation } = defineProps<{
-  landMemberInvitation: components['schemas']['LandMemberInvitation.jsonld'];
+  landMemberInvitation: Pick<components['schemas']['LandMemberInvitation.jsonld'], 'ulid'>;
 }>();
 
 const { api } = useTeraApi();
@@ -73,7 +73,7 @@ const { mutate: deleteLandMemberInvitation, isPending } = useMutation({
       title: tLandMemberInvitation('action.delete.success.message'),
       variant: 'positive',
     });
-    emit(landMemberInvitation);
+    emit();
   },
   onError: (error, variables, context) => {
     toast({

--- a/libs/tera/util-api-sdk/generated/tera-api.ts
+++ b/libs/tera/util-api-sdk/generated/tera-api.ts
@@ -1887,7 +1887,7 @@ export interface components {
        * @example pending
        * @enum {string}
        */
-      state: LandMemberInvitationState;
+      state: PathsApiLand_member_invitationsBy_emailGetParametersQueryState;
       person?: components['schemas']['Person'] | null;
       /** Format: date-time */
       acceptedAt?: string | null;
@@ -1943,7 +1943,7 @@ export interface components {
        * @example pending
        * @enum {string}
        */
-      state: LandMemberInvitationState;
+      state: PathsApiLand_member_invitationsBy_emailGetParametersQueryState;
       person?: components['schemas']['Person.jsonld'] | null;
       /** Format: date-time */
       acceptedAt?: string | null;
@@ -1966,7 +1966,7 @@ export interface components {
        * @example pending
        * @enum {string}
        */
-      state: LandMemberInvitationState;
+      state: PathsApiLand_member_invitationsBy_emailGetParametersQueryState;
       person?: components['schemas']['Person.jsonld-user.land_member_invitation.collection'] | null;
       /** Format: ulid */
       ulid?: string;
@@ -2006,7 +2006,7 @@ export interface components {
        * @example pending
        * @enum {string}
        */
-      state: LandMemberInvitationState;
+      state: PathsApiLand_member_invitationsBy_emailGetParametersQueryState;
       person?: components['schemas']['Person.jsonld-user.land_member_invitation.get'] | null;
       /** Format: ulid */
       ulid?: string;
@@ -4899,6 +4899,8 @@ export interface operations {
         pagination?: boolean;
         /** @description Filter by email */
         email: string;
+        /** @description Filter by state */
+        state?: PathsApiLand_member_invitationsBy_emailGetParametersQueryState;
       };
       header?: never;
       path?: never;
@@ -7844,6 +7846,11 @@ export interface operations {
     };
   };
 }
+export enum PathsApiLand_member_invitationsBy_emailGetParametersQueryState {
+  pending = 'pending',
+  accepted = 'accepted',
+  refused = 'refused',
+}
 export enum PathsApiLand_rolesGetParametersQueryOrderPosition {
   asc = 'asc',
   desc = 'desc',
@@ -7858,11 +7865,6 @@ export enum LandAreaState {
 export enum LandAreaKind {
   open_soil = 'open_soil',
   soil_less = 'soil_less',
-}
-export enum LandMemberInvitationState {
-  pending = 'pending',
-  accepted = 'accepted',
-  refused = 'refused',
 }
 export enum LandResearchDealState {
   opened = 'opened',

--- a/libs/tera/util-api-sdk/generated/tera-api.ts
+++ b/libs/tera/util-api-sdk/generated/tera-api.ts
@@ -400,6 +400,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/land_member_invitations/by_email': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Retrieves the collection of LandMemberInvitation resources.
+     * @description Retrieves the collection of LandMemberInvitation resources.
+     */
+    get: operations['collection-by-email'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/land_member_invitations/check_email_unicity': {
     parameters: {
       query?: never;
@@ -1297,6 +1317,20 @@ export interface components {
       /** Format: ulid */
       ulid?: string;
     };
+    'Land.jsonld-user.land_member_invitation.collection-by-email': {
+      readonly '@context'?:
+        | string
+        | ({
+            '@vocab': string;
+            /** @enum {string} */
+            hydra: LandJsonldContextHydra;
+          } & {
+            [key: string]: unknown;
+          });
+      readonly '@id'?: string;
+      readonly '@type'?: string;
+      name?: string;
+    };
     LandArea: {
       name: string;
       /**
@@ -1937,6 +1971,16 @@ export interface components {
       /** Format: ulid */
       ulid?: string;
     };
+    'LandMemberInvitation.jsonld-user.land_member_invitation.collection-by-email': {
+      readonly '@id'?: string;
+      readonly '@type'?: string;
+      land?: components['schemas']['Land.jsonld-user.land_member_invitation.collection-by-email'];
+      landRoles?: components['schemas']['LandRole.jsonld-user.land_member_invitation.collection-by-email'][];
+      /** Format: ulid */
+      ulid?: string;
+      /** Format: date-time */
+      createdAt?: string;
+    };
     'LandMemberInvitation.jsonld-user.land_member_invitation.get': {
       readonly '@context'?:
         | string
@@ -2250,6 +2294,20 @@ export interface components {
       name: string;
     };
     'LandRole.jsonld-user.land_member_invitation.collection': {
+      readonly '@context'?:
+        | string
+        | ({
+            '@vocab': string;
+            /** @enum {string} */
+            hydra: LandJsonldContextHydra;
+          } & {
+            [key: string]: unknown;
+          });
+      readonly '@id'?: string;
+      readonly '@type'?: string;
+      name: string;
+    };
+    'LandRole.jsonld-user.land_member_invitation.collection-by-email': {
       readonly '@context'?:
         | string
         | ({
@@ -4823,6 +4881,77 @@ export interface operations {
       };
       /** @description Unprocessable entity */
       422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  'collection-by-email': {
+    parameters: {
+      query: {
+        /** @description The collection page number */
+        page?: number;
+        /** @description The number of items per page */
+        itemsPerPage?: number;
+        /** @description Enable or disable pagination */
+        pagination?: boolean;
+        /** @description Filter by email */
+        email: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description LandMemberInvitation collection */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/ld+json': {
+            member: components['schemas']['LandMemberInvitation.jsonld-user.land_member_invitation.collection-by-email'][];
+            totalItems?: number;
+            /** @example {
+             *       "@id": "string",
+             *       "type": "string",
+             *       "first": "string",
+             *       "last": "string",
+             *       "previous": "string",
+             *       "next": "string"
+             *     } */
+            view?: {
+              /** Format: iri-reference */
+              '@id'?: string;
+              '@type'?: string;
+              /** Format: iri-reference */
+              first?: string;
+              /** Format: iri-reference */
+              last?: string;
+              /** Format: iri-reference */
+              previous?: string;
+              /** Format: iri-reference */
+              next?: string;
+            };
+            search?: {
+              '@type'?: string;
+              template?: string;
+              variableRepresentation?: string;
+              mapping?: {
+                '@type'?: string;
+                variable?: string;
+                property?: string | null;
+                required?: boolean;
+              }[];
+            };
+          };
+        };
+      };
+      /** @description Forbidden */
+      403: {
         headers: {
           [name: string]: unknown;
         };

--- a/libs/tera/util-events/LandMemberInvitationEvents.ts
+++ b/libs/tera/util-events/LandMemberInvitationEvents.ts
@@ -4,9 +4,9 @@ import type { EventBusKey } from '@vueuse/core';
 export const landMemberInvitationPostSucceededEvent: EventBusKey<
   components['schemas']['LandMemberInvitation.jsonld']
 > = Symbol('land-member-invitation-post-succeeded');
-export const landMemberInvitationDeleteSucceededEvent: EventBusKey<
-  components['schemas']['LandMemberInvitation.jsonld']
-> = Symbol('land-member-invitation-delete-succeeded');
+export const landMemberInvitationDeleteSucceededEvent: EventBusKey<null> = Symbol(
+  'land-member-invitation-delete-succeeded',
+);
 export const landMemberInvitationPatchSucceededEvent: EventBusKey<
   components['schemas']['LandMemberInvitation.jsonld']
 > = Symbol('land-member-invitation-patch-succeeded');

--- a/projects/tera/api/config/services.yml
+++ b/projects/tera/api/config/services.yml
@@ -56,3 +56,9 @@ services:
       $properties: { position: ~ }
     parent: 'api_platform.doctrine.orm.order_filter'
     tags: [ 'api_platform.filter' ]
+
+  land_member_invitation.state_filter:
+    arguments:
+      $properties: { state: ~ }
+    parent: 'api_platform.doctrine.orm.search_filter'
+    tags: [ 'api_platform.filter' ]

--- a/projects/tera/api/openapi_docs.json
+++ b/projects/tera/api/openapi_docs.json
@@ -2727,6 +2727,26 @@
                         "style": "form",
                         "explode": false,
                         "allowReserved": false
+                    },
+                    {
+                        "name": "state",
+                        "in": "query",
+                        "description": "Filter by state",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "pending",
+                                "accepted",
+                                "refused"
+                            ],
+                            "example": "pending"
+                        },
+                        "style": "form",
+                        "explode": false,
+                        "allowReserved": false
                     }
                 ],
                 "deprecated": false

--- a/projects/tera/api/openapi_docs.json
+++ b/projects/tera/api/openapi_docs.json
@@ -2557,6 +2557,181 @@
                 "deprecated": false
             }
         },
+        "/api/land_member_invitations/by_email": {
+            "get": {
+                "operationId": "collection-by-email",
+                "tags": [
+                    "LandMemberInvitation"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "LandMemberInvitation collection",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "member": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/LandMemberInvitation.jsonld-user.land_member_invitation.collection-by-email"
+                                            }
+                                        },
+                                        "totalItems": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                        },
+                                        "view": {
+                                            "type": "object",
+                                            "properties": {
+                                                "@id": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "@type": {
+                                                    "type": "string"
+                                                },
+                                                "first": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "last": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "previous": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "next": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                }
+                                            },
+                                            "example": {
+                                                "@id": "string",
+                                                "type": "string",
+                                                "first": "string",
+                                                "last": "string",
+                                                "previous": "string",
+                                                "next": "string"
+                                            }
+                                        },
+                                        "search": {
+                                            "type": "object",
+                                            "properties": {
+                                                "@type": {
+                                                    "type": "string"
+                                                },
+                                                "template": {
+                                                    "type": "string"
+                                                },
+                                                "variableRepresentation": {
+                                                    "type": "string"
+                                                },
+                                                "mapping": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "@type": {
+                                                                "type": "string"
+                                                            },
+                                                            "variable": {
+                                                                "type": "string"
+                                                            },
+                                                            "property": {
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "required": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "member"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    }
+                },
+                "summary": "Retrieves the collection of LandMemberInvitation resources.",
+                "description": "Retrieves the collection of LandMemberInvitation resources.",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "The collection page number",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": true,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        },
+                        "style": "form",
+                        "explode": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "itemsPerPage",
+                        "in": "query",
+                        "description": "The number of items per page",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": true,
+                        "schema": {
+                            "type": "integer",
+                            "default": 30,
+                            "minimum": 0
+                        },
+                        "style": "form",
+                        "explode": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "pagination",
+                        "in": "query",
+                        "description": "Enable or disable pagination",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": true,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "style": "form",
+                        "explode": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "email",
+                        "in": "query",
+                        "description": "Filter by email",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false,
+                        "allowReserved": false
+                    }
+                ],
+                "deprecated": false
+            }
+        },
         "/api/land_member_invitations/check_email_unicity": {
             "get": {
                 "operationId": "checkLandMemberInvitationEmailUnicity",
@@ -7336,6 +7511,51 @@
                     }
                 }
             },
+            "Land.jsonld-user.land_member_invitation.collection-by-email": {
+                "type": "object",
+                "description": "",
+                "deprecated": false,
+                "properties": {
+                    "@context": {
+                        "readOnly": true,
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "@vocab": {
+                                        "type": "string"
+                                    },
+                                    "hydra": {
+                                        "type": "string",
+                                        "enum": [
+                                            "http://www.w3.org/ns/hydra/core#"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "@vocab",
+                                    "hydra"
+                                ],
+                                "additionalProperties": true
+                            }
+                        ]
+                    },
+                    "@id": {
+                        "readOnly": true,
+                        "type": "string"
+                    },
+                    "@type": {
+                        "readOnly": true,
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
             "LandArea": {
                 "type": "object",
                 "description": "",
@@ -9217,6 +9437,38 @@
                     }
                 }
             },
+            "LandMemberInvitation.jsonld-user.land_member_invitation.collection-by-email": {
+                "type": "object",
+                "description": "",
+                "deprecated": false,
+                "properties": {
+                    "@id": {
+                        "readOnly": true,
+                        "type": "string"
+                    },
+                    "@type": {
+                        "readOnly": true,
+                        "type": "string"
+                    },
+                    "land": {
+                        "$ref": "#/components/schemas/Land.jsonld-user.land_member_invitation.collection-by-email"
+                    },
+                    "landRoles": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/LandRole.jsonld-user.land_member_invitation.collection-by-email"
+                        }
+                    },
+                    "ulid": {
+                        "type": "string",
+                        "format": "ulid"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            },
             "LandMemberInvitation.jsonld-user.land_member_invitation.get": {
                 "type": "object",
                 "description": "",
@@ -10037,6 +10289,54 @@
                 }
             },
             "LandRole.jsonld-user.land_member_invitation.collection": {
+                "type": "object",
+                "description": "",
+                "deprecated": false,
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "@context": {
+                        "readOnly": true,
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "@vocab": {
+                                        "type": "string"
+                                    },
+                                    "hydra": {
+                                        "type": "string",
+                                        "enum": [
+                                            "http://www.w3.org/ns/hydra/core#"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "@vocab",
+                                    "hydra"
+                                ],
+                                "additionalProperties": true
+                            }
+                        ]
+                    },
+                    "@id": {
+                        "readOnly": true,
+                        "type": "string"
+                    },
+                    "@type": {
+                        "readOnly": true,
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "LandRole.jsonld-user.land_member_invitation.collection-by-email": {
                 "type": "object",
                 "description": "",
                 "deprecated": false,

--- a/projects/tera/api/src/DataFixtures/LandMemberInvitationFixtures.php
+++ b/projects/tera/api/src/DataFixtures/LandMemberInvitationFixtures.php
@@ -18,6 +18,12 @@ class LandMemberInvitationFixtures extends Fixture implements DependentFixtureIn
             'email' => PersonFixtures::buildUserEmail(PersonFixtures::PERSON_6),
             'landRoles' => [$this->getReference(LandRoleFixtures::LAND_1_ROLE_COLLABORATOR, LandRole::class)],
         ]);
+
+        LandMemberInvitationFactory::new()->create([
+            'land' => $this->getReference(LandFixtures::LAND_4, Land::class),
+            'email' => PersonFixtures::buildUserEmail(PersonFixtures::PERSON_1),
+            'landRoles' => [$this->getReference(LandRoleFixtures::LAND_1_ROLE_COLLABORATOR, LandRole::class)],
+        ]);
     }
 
     public function getDependencies(): array

--- a/projects/tera/api/src/Doctrine/Filter/EmailFilter.php
+++ b/projects/tera/api/src/Doctrine/Filter/EmailFilter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Doctrine\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+
+class EmailFilter extends AbstractFilter
+{
+
+    public function __construct(ManagerRegistry $managerRegistry, ?LoggerInterface $logger = null, ?array $properties = null, ?NameConverterInterface $nameConverter = null)
+    {
+        parent::__construct($managerRegistry, $logger, $properties, $nameConverter);
+    }
+
+    public function getDescription(string $resourceClass): array
+    {
+        return [];
+    }
+
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
+    {
+
+        if ('email' !== $property) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0];
+
+
+        $queryBuilder
+            ->andWhere(sprintf('%s.email = :email', $alias))
+            ->setParameter('email', $value);
+    }
+}

--- a/projects/tera/api/src/Entity/Land.php
+++ b/projects/tera/api/src/Entity/Land.php
@@ -58,7 +58,7 @@ class Land extends AbstractIdOrmAndUlidApiIdentified implements LandAwareInterfa
     public ?Person $owner = null;
 
     #[ORM\Column(length: 255)]
-    #[Groups(["user:land:get-collection-looking-for-members", "user:land:collection", "user:land:get", "user:land:patch", "user:land:post"])]
+    #[Groups(["user:land:get-collection-looking-for-members", "user:land:collection", "user:land:get", "user:land:patch", "user:land:post", "user:land_member_invitation:collection-by-email"])]
     private ?string $name = null;
 
     /**

--- a/projects/tera/api/src/Entity/LandMemberInvitation.php
+++ b/projects/tera/api/src/Entity/LandMemberInvitation.php
@@ -78,7 +78,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[GetCollection(
     uriTemplate: '/land_member_invitations/by_email',
     normalizationContext: ['groups' => ['user:land_member_invitation:collection-by-email']],
-    security: "true",
+    security: "user.getEmail() === request.query.get('email')",
     name: 'collection-by-email',
     parameters: [
         new QueryParameter(
@@ -93,7 +93,8 @@ use Symfony\Component\Validator\Constraints as Assert;
             ),
             filter: EmailFilter::class,
             required: true
-        )
+        ),
+        new QueryParameter(key: 'state', schema: ['type' => 'string', 'enum' => LandMemberInvitationWorkflowPlace::PLACES, 'example' => LandMemberInvitationWorkflowPlace::PENDING], openApi: new Parameter(name: 'state', in: 'query', description: 'Filter by state', required: false, allowEmptyValue: true), filter: 'land_member_invitation.state_filter')
     ]
 )]
 #[Get(

--- a/projects/tera/api/src/Entity/LandRole.php
+++ b/projects/tera/api/src/Entity/LandRole.php
@@ -48,7 +48,7 @@ class LandRole extends AbstractIdOrmAndUlidApiIdentified implements LandAwareInt
     use PositionTrait;
 
     #[ORM\Column(length: 255)]
-    #[Groups(["user:land_role:collection", "user:land_member:collection", "user:land_member_invitation:collection", "user:land_role:get", "user:land_role:patch", "user:land_role:post"])]
+    #[Groups(["user:land_role:collection", "user:land_member:collection", "user:land_member_invitation:collection", "user:land_role:get", "user:land_role:patch", "user:land_role:post", "user:land_member_invitation:collection-by-email"])]
     #[Assert\NotBlank()]
     private ?string $name = null;
 

--- a/projects/tera/api/tests/Security/LandMemberInvitationSecurityTest.php
+++ b/projects/tera/api/tests/Security/LandMemberInvitationSecurityTest.php
@@ -235,4 +235,16 @@ class LandMemberInvitationSecurityTest extends AbstractApiTestCase
                 ]])
             ->assertStatus(401);
     }
+
+    public function testCollectionByEmail()
+    {
+        $context1 = $this->createLandContext();
+        $context2 = $this->createLandContext();
+        $this->addOneLandRole($context1);
+        $this->addOneLandMemberInvitation($context1, [$context1->landRoles[0]], $context2->owner->getEmail());
+
+        $this->browser()->actingAs($context1->owner)
+            ->get('/api/land_member_invitations/by_email', ['query' => ['email' => $context2->owner->getEmail()]])
+            ->assertStatus(403);
+    }
 }

--- a/projects/tera/app/src/layouts/in-app/TheLayout.vue
+++ b/projects/tera/app/src/layouts/in-app/TheLayout.vue
@@ -107,6 +107,7 @@ import {
   landPostSucceededEvent,
   landPatchSucceededEvent,
 } from '@lychen/tera-util-events/LandEvents';
+import { landMemberInvitationAcceptSucceededEvent } from '@lychen/tera-util-events/LandMemberInvitationEvents';
 import DialogTeraLandCreate from '@lychen/tera-ui-components/land/dialogs/create/DialogTeraLandCreate.vue';
 import { ref } from 'vue';
 
@@ -204,6 +205,12 @@ onLandDelete(() => {
 const { on: onLandUpdate } = useEventBus(landPatchSucceededEvent);
 
 onLandUpdate(() => {
+  refetch();
+});
+
+const { on: onLandMemberInvitationAccept } = useEventBus(landMemberInvitationAcceptSucceededEvent);
+
+onLandMemberInvitationAccept(() => {
   refetch();
 });
 

--- a/projects/tera/app/src/pages/lands/PageLands.vue
+++ b/projects/tera/app/src/pages/lands/PageLands.vue
@@ -36,6 +36,12 @@
         v-if="lands?.member"
         class="grid gap-8 grid-cols-(--grid-fluid) auto-rows-(--grid-rows-fluid)"
       >
+        <CardTeraLandMemberInvitation
+          v-for="landMemberInvitation in landMemberInvitations.member"
+          :key="landMemberInvitation.ulid"
+          :land-member-invitation="landMemberInvitation"
+          :land-roles="landMemberInvitation.landRoles"
+        />
         <RouterLink
           v-for="land in lands.member"
           :key="land.ulid"
@@ -71,6 +77,8 @@ import BaseHeading from '@lychen/vue-ui-components-app/base-heading/BaseHeading.
 import { messages, TRANSLATION_KEY } from './i18n';
 import { useI18nExtended } from '@lychen/vue-i18n-util-composables/useI18nExtended';
 import { useTeraApi } from '@lychen/tera-util-api-sdk/composables/useTeraApi';
+import CardTeraLandMemberInvitation from '@lychen/tera-ui-components/land-member-invitation/card/CardTeraLandMemberInvitation.vue';
+import zitadelAuth from '@lychen/typescript-util-zitadel/ZitadelAuth';
 
 const { t } = useI18nExtended({ messages, rootKey: TRANSLATION_KEY, prefixed: true });
 
@@ -82,6 +90,21 @@ const { data: lands, refetch } = useQuery({
   queryKey: ['lands'],
   queryFn: async () => {
     const response = await api.GET('/api/lands');
+    return response.data;
+  },
+});
+
+const email = zitadelAuth.oidcAuth.userProfile.email;
+
+const { data: landMemberInvitations } = useQuery({
+  queryKey: ['landMemberInvitations'],
+  queryFn: async () => {
+    if (!email) {
+      throw new Error('missing.email');
+    }
+    const response = await api.GET('/api/land_member_invitations/by_email', {
+      params: { query: { email } },
+    });
     return response.data;
   },
 });

--- a/projects/tera/app/src/pages/lands/PageLands.vue
+++ b/projects/tera/app/src/pages/lands/PageLands.vue
@@ -92,6 +92,7 @@ import {
   landMemberInvitationAcceptSucceededEvent,
   landMemberInvitationRefuseSucceededEvent,
 } from '@lychen/tera-util-events/LandMemberInvitationEvents';
+import { PathsApiLand_member_invitationsBy_emailGetParametersQueryState } from '@lychen/tera-util-api-sdk/generated/tera-api';
 
 const { t } = useI18nExtended({ messages, rootKey: TRANSLATION_KEY, prefixed: true });
 
@@ -116,7 +117,12 @@ const { data: landMemberInvitations, refetch: refetchLandMemberInvitations } = u
       throw new Error('missing.email');
     }
     const response = await api.GET('/api/land_member_invitations/by_email', {
-      params: { query: { email } },
+      params: {
+        query: {
+          email,
+          state: PathsApiLand_member_invitationsBy_emailGetParametersQueryState.pending,
+        },
+      },
     });
     return response.data;
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint to retrieve land member invitations filtered by email.
	- Enhanced the lands page with a new display card that dynamically shows invitations based on the authenticated user’s email.
	- Added localization support for invitation messages in English and French.

- **Bug Fixes**
	- Improved error handling for missing email in the land member invitations query.

- **Tests**
	- Added automated testing to validate the filtering and display of land member invitations.
	- Added security tests to ensure proper access control for the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->