### PR TITLE
Update vite to 6.2.6

### DIFF
--- a/libs/vite/util-ssg/package.json
+++ b/libs/vite/util-ssg/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-ssg": "^26.1.1"
   }
 }

--- a/projects/design/package.json
+++ b/projects/design/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-ssg": "^26.1.1",
     "vite-ssg-sitemap": "^0.8.1"

--- a/projects/eko/website/package.json
+++ b/projects/eko/website/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-ssg": "^26.1.1",
     "vite-ssg-sitemap": "^0.8.1"

--- a/projects/humu/website/package.json
+++ b/projects/humu/website/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-ssg": "^26.1.1",
     "vite-ssg-sitemap": "^0.8.1"

--- a/projects/kiro/member-app/package.json
+++ b/projects/kiro/member-app/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-plugin-pwa": "^1.0.0"
   }

--- a/projects/kiro/website/package.json
+++ b/projects/kiro/website/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-ssg": "^26.1.1",
     "vite-ssg-sitemap": "^0.8.1"

--- a/projects/kolo/website/package.json
+++ b/projects/kolo/website/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-ssg": "^26.1.1",
     "vite-ssg-sitemap": "^0.8.1"

--- a/projects/luna/website/package.json
+++ b/projects/luna/website/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-ssg": "^26.1.1",
     "vite-ssg-sitemap": "^0.8.1"

--- a/projects/meli/website/package.json
+++ b/projects/meli/website/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-ssg": "^26.1.1",
     "vite-ssg-sitemap": "^0.8.1"

--- a/projects/myko/website/package.json
+++ b/projects/myko/website/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-ssg": "^26.1.1",
     "vite-ssg-sitemap": "^0.8.1"

--- a/projects/novi/website/package.json
+++ b/projects/novi/website/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-ssg": "^26.1.1",
     "vite-ssg-sitemap": "^0.8.1"

--- a/projects/robust/website/package.json
+++ b/projects/robust/website/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-ssg": "^26.1.1",
     "vite-ssg-sitemap": "^0.8.1"

--- a/projects/storybook/package.json
+++ b/projects/storybook/package.json
@@ -35,7 +35,7 @@
     "storybook-dark-mode": "^4.0.2",
     "tailwindcss": "^4.1.3",
     "typescript": "~5.7.2",
-    "vite": "^6.2.0",
+    "vite": "^6.2.6",
     "vue-tsc": "^2.2.4"
   }
 }

--- a/projects/tera/app/package.json
+++ b/projects/tera/app/package.json
@@ -37,7 +37,7 @@
     "@vite-pwa/assets-generator": "^1.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
     "tailwindcss": "^4.1.3",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-plugin-pwa": "^1.0.0"
   }

--- a/projects/tera/website/package.json
+++ b/projects/tera/website/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-ssg": "^26.1.1",
     "vite-ssg-sitemap": "^0.8.1"

--- a/projects/vara/website/package.json
+++ b/projects/vara/website/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-ssg": "^26.1.1",
     "vite-ssg-sitemap": "^0.8.1"

--- a/projects/website/package.json
+++ b/projects/website/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.2.4",
+    "vite": "^6.2.6",
     "vite-plugin-mkcert": "^1.17.7",
     "vite-ssg": "^26.1.1",
     "vite-ssg-sitemap": "^0.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,7 +2075,7 @@ __metadata:
     "@unhead/vue": "npm:^1.11.14"
     "@vitejs/plugin-vue": "npm:^5.2.1"
     unhead: "npm:^1.11.14"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-ssg: "npm:^26.1.1"
     vite-ssg-sitemap: "npm:^0.8.1"
@@ -2146,7 +2146,7 @@ __metadata:
     "@unhead/vue": "npm:^1.11.14"
     "@vitejs/plugin-vue": "npm:^5.2.1"
     unhead: "npm:^1.11.14"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-ssg: "npm:^26.1.1"
     vite-ssg-sitemap: "npm:^0.8.1"
@@ -2209,7 +2209,7 @@ __metadata:
     "@unhead/vue": "npm:^1.11.14"
     "@vitejs/plugin-vue": "npm:^5.2.1"
     unhead: "npm:^1.11.14"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-ssg: "npm:^26.1.1"
     vite-ssg-sitemap: "npm:^0.8.1"
@@ -2232,7 +2232,7 @@ __metadata:
     "@vitejs/plugin-vue": "npm:^5.2.1"
     "@vueuse/core": "npm:^13.0.0"
     "@zitadel/vue": "npm:1.1.1"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-plugin-pwa: "npm:^1.0.0"
     vue: "npm:^3.5.13"
@@ -2312,7 +2312,7 @@ __metadata:
     "@unhead/vue": "npm:^1.11.14"
     "@vitejs/plugin-vue": "npm:^5.2.1"
     unhead: "npm:^1.11.14"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-ssg: "npm:^26.1.1"
     vite-ssg-sitemap: "npm:^0.8.1"
@@ -2375,7 +2375,7 @@ __metadata:
     "@unhead/vue": "npm:^1.11.14"
     "@vitejs/plugin-vue": "npm:^5.2.1"
     unhead: "npm:^1.11.14"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-ssg: "npm:^26.1.1"
     vite-ssg-sitemap: "npm:^0.8.1"
@@ -2438,7 +2438,7 @@ __metadata:
     "@unhead/vue": "npm:^1.11.14"
     "@vitejs/plugin-vue": "npm:^5.2.1"
     unhead: "npm:^1.11.14"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-ssg: "npm:^26.1.1"
     vite-ssg-sitemap: "npm:^0.8.1"
@@ -2501,7 +2501,7 @@ __metadata:
     "@unhead/vue": "npm:^1.11.14"
     "@vitejs/plugin-vue": "npm:^5.2.1"
     unhead: "npm:^1.11.14"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-ssg: "npm:^26.1.1"
     vite-ssg-sitemap: "npm:^0.8.1"
@@ -2564,7 +2564,7 @@ __metadata:
     "@unhead/vue": "npm:^1.11.14"
     "@vitejs/plugin-vue": "npm:^5.2.1"
     unhead: "npm:^1.11.14"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-ssg: "npm:^26.1.1"
     vite-ssg-sitemap: "npm:^0.8.1"
@@ -2627,7 +2627,7 @@ __metadata:
     "@unhead/vue": "npm:^1.11.14"
     "@vitejs/plugin-vue": "npm:^5.2.1"
     unhead: "npm:^1.11.14"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-ssg: "npm:^26.1.1"
     vite-ssg-sitemap: "npm:^0.8.1"
@@ -2718,7 +2718,7 @@ __metadata:
     "@unhead/vue": "npm:^1.11.14"
     "@vitejs/plugin-vue": "npm:^5.2.1"
     unhead: "npm:^1.11.14"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-ssg: "npm:^26.1.1"
     vite-ssg-sitemap: "npm:^0.8.1"
@@ -2752,7 +2752,7 @@ __metadata:
     storybook-dark-mode: "npm:^4.0.2"
     tailwindcss: "npm:^4.1.3"
     typescript: "npm:~5.7.2"
-    vite: "npm:^6.2.0"
+    vite: "npm:^6.2.6"
     vue: "npm:^3.5.13"
     vue-tsc: "npm:^2.2.4"
   languageName: unknown
@@ -2785,7 +2785,7 @@ __metadata:
     "@vitejs/plugin-vue": "npm:^5.2.1"
     "@vueuse/core": "npm:^13.0.0"
     tailwindcss: "npm:^4.1.3"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-plugin-pwa: "npm:^1.0.0"
     vue: "npm:^3.5.13"
@@ -2913,7 +2913,7 @@ __metadata:
     "@unhead/vue": "npm:^1.11.14"
     "@vitejs/plugin-vue": "npm:^5.2.1"
     unhead: "npm:^1.11.14"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-ssg: "npm:^26.1.1"
     vite-ssg-sitemap: "npm:^0.8.1"
@@ -3059,7 +3059,7 @@ __metadata:
     "@unhead/vue": "npm:^1.11.14"
     "@vitejs/plugin-vue": "npm:^5.2.1"
     unhead: "npm:^1.11.14"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-ssg: "npm:^26.1.1"
     vite-ssg-sitemap: "npm:^0.8.1"
@@ -3075,7 +3075,7 @@ __metadata:
     "@lychen/vue-i18n-util-configs": "workspace:*"
     "@lychen/vue-router-util-configs": "workspace:*"
     "@vitejs/plugin-vue": "npm:^5.2.1"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-ssg: "npm:^26.1.1"
     vue: "npm:^3.5.13"
     vue-router: "npm:^4.5.0"
@@ -3316,7 +3316,7 @@ __metadata:
     "@unhead/vue": "npm:^1.11.14"
     "@vitejs/plugin-vue": "npm:^5.2.1"
     unhead: "npm:^1.11.14"
-    vite: "npm:^6.2.4"
+    vite: "npm:^6.2.6"
     vite-plugin-mkcert: "npm:^1.17.7"
     vite-ssg: "npm:^26.1.1"
     vite-ssg-sitemap: "npm:^0.8.1"
@@ -3562,135 +3562,142 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.34.7"
+"@rollup/rollup-android-arm-eabi@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.40.0"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm64@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-android-arm64@npm:4.34.7"
+"@rollup/rollup-android-arm64@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-android-arm64@npm:4.40.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.34.7"
+"@rollup/rollup-darwin-arm64@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.40.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-x64@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-darwin-x64@npm:4.34.7"
+"@rollup/rollup-darwin-x64@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-darwin-x64@npm:4.40.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-arm64@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.34.7"
+"@rollup/rollup-freebsd-arm64@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.40.0"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-x64@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.34.7"
+"@rollup/rollup-freebsd-x64@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.40.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.34.7"
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.40.0"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-musleabihf@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.34.7"
+"@rollup/rollup-linux-arm-musleabihf@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.40.0"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-gnu@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.34.7"
+"@rollup/rollup-linux-arm64-gnu@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.40.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.34.7"
+"@rollup/rollup-linux-arm64-musl@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.40.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-loongarch64-gnu@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.34.7"
+"@rollup/rollup-linux-loongarch64-gnu@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.40.0"
   conditions: os=linux & cpu=loong64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-powerpc64le-gnu@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.34.7"
+"@rollup/rollup-linux-powerpc64le-gnu@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.40.0"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-gnu@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.34.7"
+"@rollup/rollup-linux-riscv64-gnu@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.40.0"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-s390x-gnu@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.34.7"
+"@rollup/rollup-linux-riscv64-musl@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.40.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.40.0"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.34.7"
+"@rollup/rollup-linux-x64-gnu@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.40.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-musl@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.34.7"
+"@rollup/rollup-linux-x64-musl@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.40.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.34.7"
+"@rollup/rollup-win32-arm64-msvc@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.40.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.34.7"
+"@rollup/rollup-win32-ia32-msvc@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.40.0"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-msvc@npm:4.34.7":
-  version: 4.34.7
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.34.7"
+"@rollup/rollup-win32-x64-msvc@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.40.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4648,7 +4655,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:1.0.6, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6":
+"@types/estree@npm:*, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6":
   version: 1.0.6
   resolution: "@types/estree@npm:1.0.6"
   checksum: 10c0/cdfd751f6f9065442cd40957c07fd80361c962869aa853c1c2fd03e101af8b9389d8ff4955a43a6fcfa223dd387a089937f95be0f3eec21ca527039fd2d9859a
@@ -4659,6 +4666,13 @@ __metadata:
   version: 0.0.39
   resolution: "@types/estree@npm:0.0.39"
   checksum: 10c0/f0af6c95ac1988c4827964bd9d3b51d24da442e2188943f6dfcb1e1559103d5d024d564b2e9d3f84c53714a02a0a7435c7441138eb63d9af5de4dfc66cdc0d92
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:1.0.7":
+  version: 1.0.7
+  resolution: "@types/estree@npm:1.0.7"
+  checksum: 10c0/be815254316882f7c40847336cd484c3bc1c3e34f710d197160d455dc9d6d050ffbf4c3bc76585dba86f737f020ab20bdb137ebe0e9116b0c86c7c0342221b8c
   languageName: node
   linkType: hard
 
@@ -7297,6 +7311,18 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10c0/d13c10120e9625adf21d8d80481586200759928c19405a816b77dd28eaeb80e7c59c5def3e2941508045eb06d34eb47fad865ccc8bf98e6ab988bb0ed160fb6f
+  languageName: node
+  linkType: hard
+
+"fdir@npm:^6.4.4":
+  version: 6.4.4
+  resolution: "fdir@npm:6.4.4"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 10c0/6ccc33be16945ee7bc841e1b4178c0b4cf18d3804894cb482aa514651c962a162f96da7ffc6ebfaf0df311689fb70091b04dd6caffe28d56b9ebdc0e7ccadfdd
   languageName: node
   linkType: hard
 
@@ -10883,30 +10909,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^4.30.1":
-  version: 4.34.7
-  resolution: "rollup@npm:4.34.7"
+"rollup@npm:^4.34.9":
+  version: 4.40.0
+  resolution: "rollup@npm:4.40.0"
   dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.34.7"
-    "@rollup/rollup-android-arm64": "npm:4.34.7"
-    "@rollup/rollup-darwin-arm64": "npm:4.34.7"
-    "@rollup/rollup-darwin-x64": "npm:4.34.7"
-    "@rollup/rollup-freebsd-arm64": "npm:4.34.7"
-    "@rollup/rollup-freebsd-x64": "npm:4.34.7"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.34.7"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.34.7"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.34.7"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.34.7"
-    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.34.7"
-    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.34.7"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.34.7"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.34.7"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.34.7"
-    "@rollup/rollup-linux-x64-musl": "npm:4.34.7"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.34.7"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.34.7"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.34.7"
-    "@types/estree": "npm:1.0.6"
+    "@rollup/rollup-android-arm-eabi": "npm:4.40.0"
+    "@rollup/rollup-android-arm64": "npm:4.40.0"
+    "@rollup/rollup-darwin-arm64": "npm:4.40.0"
+    "@rollup/rollup-darwin-x64": "npm:4.40.0"
+    "@rollup/rollup-freebsd-arm64": "npm:4.40.0"
+    "@rollup/rollup-freebsd-x64": "npm:4.40.0"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.40.0"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.40.0"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.40.0"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.40.0"
+    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.40.0"
+    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.40.0"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.40.0"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.40.0"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.40.0"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.40.0"
+    "@rollup/rollup-linux-x64-musl": "npm:4.40.0"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.40.0"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.40.0"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.40.0"
+    "@types/estree": "npm:1.0.7"
     fsevents: "npm:~2.3.2"
   dependenciesMeta:
     "@rollup/rollup-android-arm-eabi":
@@ -10935,6 +10962,8 @@ __metadata:
       optional: true
     "@rollup/rollup-linux-riscv64-gnu":
       optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
     "@rollup/rollup-linux-s390x-gnu":
       optional: true
     "@rollup/rollup-linux-x64-gnu":
@@ -10951,7 +10980,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 10c0/115094e41ff8329e2320a7d37edb4d958aca678f8222b4b52e98981da700678c2ad92fddaf164455ca8c2cf9222d42e7b19a0f0e54bfb070b0b8c62d8f3e99aa
+  checksum: 10c0/90aa57487d4a9a7de1a47bf42a6091f83f1cb7fe1814650dfec278ab8ddae5736b86535d4c766493517720f334dfd4aa0635405ca8f4f36ed8d3c0f875f2a801
   languageName: node
   linkType: hard
 
@@ -11745,6 +11774,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinyglobby@npm:^0.2.13":
+  version: 0.2.13
+  resolution: "tinyglobby@npm:0.2.13"
+  dependencies:
+    fdir: "npm:^6.4.4"
+    picomatch: "npm:^4.0.2"
+  checksum: 10c0/ef07dfaa7b26936601d3f6d999f7928a4d1c6234c5eb36896bb88681947c0d459b7ebe797022400e555fe4b894db06e922b95d0ce60cb05fd827a0a66326b18c
+  languageName: node
+  linkType: hard
+
 "tinyrainbow@npm:^1.2.0":
   version: 1.2.0
   resolution: "tinyrainbow@npm:1.2.0"
@@ -12403,14 +12442,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^6.2.0, vite@npm:^6.2.4":
-  version: 6.2.4
-  resolution: "vite@npm:6.2.4"
+"vite@npm:^6.2.6":
+  version: 6.3.3
+  resolution: "vite@npm:6.3.3"
   dependencies:
     esbuild: "npm:^0.25.0"
+    fdir: "npm:^6.4.4"
     fsevents: "npm:~2.3.3"
+    picomatch: "npm:^4.0.2"
     postcss: "npm:^8.5.3"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
+    tinyglobby: "npm:^0.2.13"
   peerDependencies:
     "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
     jiti: ">=1.21.0"
@@ -12451,7 +12493,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/5a011ee5cce91de023a22564a314f04bf64d0d02b420d92c3d539d10257448d60e98e52b491404656426fba4a50dc25f107282540d7388fc5303dc441280155e
+  checksum: 10c0/7ea27d2c80a9e0b7ccf6cbd6c251455501286568160e8b632984e5332440f21a6d05f9236408212ba7653f7d2d4790f848956d8a620bbf4dd2ecb792a2fe1ab1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the development dependency version of Vite from 6.2.4 (or 6.2.0) to 6.2.6 across multiple projects. No changes to user-facing features or configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->