### PR TITLE
Change and add translations to tab titles

### DIFF
--- a/projects/espace/website/src/App.vue
+++ b/projects/espace/website/src/App.vue
@@ -9,11 +9,16 @@ import { usePreferredColorScheme } from '@lychen/vue-color-scheme/composables/us
 import { TooltipProvider } from '@lychen/vue-components-core/tooltip';
 import { defineOrganization, defineWebPage, defineWebSite } from '@unhead/schema-org';
 import { useHead } from '@unhead/vue';
+import { useI18nExtended } from '@lychen/vue-i18n/composables/useI18nExtended';
 
 usePreferredColorScheme();
+const { locale } = useI18nExtended();
 const title = 'espace';
 useHead({
   titleTemplate: `${title} | %s`,
+  htmlAttrs: {
+    lang: locale.value,
+  },
   templateParams: {
     schemaOrg: {
       host: import.meta.env.VITE_UNHEAD_HOST,

--- a/projects/espace/website/src/App.vue
+++ b/projects/espace/website/src/App.vue
@@ -17,7 +17,7 @@ const title = 'espace';
 useHead({
   titleTemplate: `${title} | %s`,
   htmlAttrs: {
-    lang: locale.value,
+    lang: () => locale.value,
   },
   templateParams: {
     schemaOrg: {

--- a/projects/espace/website/src/views/home/View.vue
+++ b/projects/espace/website/src/views/home/View.vue
@@ -172,8 +172,11 @@ import planetPluton from './assets/planet-pluton.png';
 import planetMars from './assets/planet-mars.png';
 import { Popover, PopoverContent, PopoverTrigger } from '@lychen/vue-components-core/popover';
 import { LINK } from '@lychen/typescript-espace/constants/App';
+import { useExtendedHead } from '@lychen/vue-unhead-composables/useExtendedHead';
 
 const { t } = usePrefixedI18n(CONFIG);
+
+useExtendedHead(t);
 
 const planets = [
   { id: 'earth', img: planetEarth },

--- a/projects/espace/website/src/views/home/i18n/en-US.json
+++ b/projects/espace/website/src/views/home/i18n/en-US.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "title": "Espace Lychen - Food Autonomy Collective",
+    "title": "Food Autonomy Collective",
     "description": "Find a cultivation space or share yours to increase food autonomy and create social links."
   },
   "hero": {

--- a/projects/espace/website/src/views/home/i18n/fr-FR.json
+++ b/projects/espace/website/src/views/home/i18n/fr-FR.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "title": "Espace Lychen - Collectif d'autonomie alimentaire",
+    "title": "Collectif d'autonomie alimentaire",
     "description": "Trouvez un espace de culture ou partagez le vôtre pour augmenter l'autonomie alimentaire et créer des liens sociaux."
   },
   "hero": {

--- a/projects/website/src/App.vue
+++ b/projects/website/src/App.vue
@@ -22,7 +22,7 @@ const { locale } = useI18nExtended();
 useHead({
   titleTemplate: 'lychen | %s',
   htmlAttrs: {
-    lang: locale.value,
+    lang: () => locale.value,
   },
   templateParams: {
     schemaOrg: {

--- a/projects/website/src/views/charter/View.vue
+++ b/projects/website/src/views/charter/View.vue
@@ -1,7 +1,7 @@
 <template>
   <Container class="flex flex-col items-center gap-4 pt-20">
-    <Title variant="h1">{{ t('title') }}</Title>
-    <Paragraph class="text-center opacity-80">{{ t('description') }}</Paragraph>
+    <Title variant="h1">{{ t('meta.title') }}</Title>
+    <Paragraph class="text-center opacity-80">{{ t('meta.description') }}</Paragraph>
     <p class="text-xs font-light italic opacity-60">
       {{ t('document_change') }}
       <a
@@ -61,6 +61,9 @@ import Title from '@lychen/vue-components-website/title/Title.vue';
 import Paragraph from '@lychen/vue-components-website/paragraph/Paragraph.vue';
 import CharterSection from './CharterSection.vue';
 import CharterArticle from './CharterArticle.vue';
+import { useExtendedHead } from '@lychen/vue-unhead-composables/useExtendedHead';
 
 const { t } = usePrefixedI18n(CONFIG);
+
+useExtendedHead(t);
 </script>

--- a/projects/website/src/views/charter/i18n/en-US.json
+++ b/projects/website/src/views/charter/i18n/en-US.json
@@ -1,6 +1,8 @@
 {
-  "title": "Our charter",
-  "description": "This charter defines the fundamental principles, ethical values, and operating rules that guide our collective action. It serves as a compass for every actor, ensuring the coherence, integrity, and sustainability of our ecosystem.",
+  "meta": {
+    "title": "Our charter",
+    "description": "This charter defines the fundamental principles, ethical values, and operating rules that guide our collective action. It serves as a compass for every actor, ensuring the coherence, integrity, and sustainability of our ecosystem."
+  },
   "document_change": "This document changes over time: everything is tracked here",
   "charter": {
     "section": {

--- a/projects/website/src/views/charter/i18n/fr-FR.json
+++ b/projects/website/src/views/charter/i18n/fr-FR.json
@@ -1,6 +1,8 @@
 {
-  "title": "Notre charte",
-  "description": "Cette charte définit les principes fondamentaux, les valeurs éthiques et les règles de fonctionnement qui guident notre action collective. Elle sert de boussole pour chaque acteur, garantissant la cohérence, l'intégrité et la pérennité de notre écosystème.",
+  "meta": {
+    "title": "Notre charte",
+    "description": "Cette charte définit les principes fondamentaux, les valeurs éthiques et les règles de fonctionnement qui guident notre action collective. Elle sert de boussole pour chaque acteur, garantissant la cohérence, l'intégrité et la pérennité de notre écosystème."
+  },
   "document_change": "Ce document change dans le temps : tout est traqué ici",
   "charter": {
     "section": {

--- a/projects/website/src/views/mission/View.vue
+++ b/projects/website/src/views/mission/View.vue
@@ -1,7 +1,7 @@
 <template>
   <Container class="flex flex-col items-center gap-8 pt-20 text-center">
-    <Title variant="h1">{{ t('title') }}</Title>
-    <Paragraph>{{ t('description') }}</Paragraph>
+    <Title variant="h1">{{ t('meta.title') }}</Title>
+    <Paragraph>{{ t('meta.description') }}</Paragraph>
   </Container>
 
   <Container class="flex flex-col items-center gap-8 pt-20 text-center">
@@ -51,6 +51,8 @@ import { CONFIG } from './i18n';
 import Container from '@lychen/vue-components-website/container/Container.vue';
 import Title from '@lychen/vue-components-website/title/Title.vue';
 import Paragraph from '@lychen/vue-components-website/paragraph/Paragraph.vue';
+import { useExtendedHead } from '@lychen/vue-unhead-composables/useExtendedHead';
 
 const { t } = usePrefixedI18n(CONFIG);
+useExtendedHead(t);
 </script>

--- a/projects/website/src/views/mission/i18n/en-US.json
+++ b/projects/website/src/views/mission/i18n/en-US.json
@@ -1,6 +1,8 @@
 {
-  "title": "A Mission for Resilience",
-  "description": "We put technology at the service of life. Our ambition is to provide territories with the tools to understand, preserve, and regenerate their ecosystems.",
+  "meta": {
+    "title": "A Mission for Resilience",
+    "description": "We put technology at the service of life. Our ambition is to provide territories with the tools to understand, preserve, and regenerate their ecosystems."
+  },
   "goals": {
     "title": "Our Areas of Impact",
     "description": "To meet the challenges of our century, we structure our action around three complementary pillars.",

--- a/projects/website/src/views/mission/i18n/fr-FR.json
+++ b/projects/website/src/views/mission/i18n/fr-FR.json
@@ -1,6 +1,8 @@
 {
-  "title": "Une Mission pour la Résilience",
-  "description": "Nous mettons la technologie au service du vivant. Notre ambition est de fournir aux territoires les outils pour comprendre, préserver et régénérer leurs écosystèmes.",
+  "meta": {
+    "title": "Une Mission pour la Résilience",
+    "description": "Nous mettons la technologie au service du vivant. Notre ambition est de fournir aux territoires les outils pour comprendre, préserver et régénérer leurs écosystèmes."
+  },
   "goals": {
     "title": "Nos Axes d'Impact",
     "description": "Pour relever les défis de notre siècle, nous structurons notre action autour de trois piliers complémentaires.",

--- a/projects/website/src/views/team/View.vue
+++ b/projects/website/src/views/team/View.vue
@@ -114,8 +114,10 @@ import { ref } from 'vue';
 import CardPerson from '@/views/team/CardPerson.vue';
 import Title from '@lychen/vue-components-website/title/Title.vue';
 import BentoCard from '@/views/team/BentoCard.vue';
+import { useExtendedHead } from '@lychen/vue-unhead-composables/useExtendedHead';
 
 const { t } = usePrefixedI18n(CONFIG);
+useExtendedHead(t);
 
 const contactEmail = ref(EMAIL.Contact);
 const { copy, isSupported } = useClipboard({ source: contactEmail });

--- a/projects/website/src/views/team/View.vue
+++ b/projects/website/src/views/team/View.vue
@@ -1,7 +1,7 @@
 <template>
   <Container class="flex flex-col items-center gap-4 pt-20">
-    <Title variant="h1">{{ t('title') }}</Title>
-    <Paragraph class="w-3/4 text-center opacity-60">{{ t('header_subtitle') }}</Paragraph>
+    <Title variant="h1">{{ t('meta.title') }}</Title>
+    <Paragraph class="w-3/4 text-center opacity-60">{{ t('meta.description') }}</Paragraph>
     <div
       class="grid-rows-auto grid h-180 w-full grid-cols-2 gap-4 px-4 md:grid-cols-4 md:grid-rows-3 md:px-20"
     >

--- a/projects/website/src/views/team/i18n/en-US.json
+++ b/projects/website/src/views/team/i18n/en-US.json
@@ -1,5 +1,7 @@
 {
-  "title": "Our Team",
+  "meta": {
+    "title": "Our Team"
+  },
   "header_subtitle": "Developing the robustness and resilience of territories in the face of climate change.",
   "team_section": {
     "title": "The Lychen Team",

--- a/projects/website/src/views/team/i18n/en-US.json
+++ b/projects/website/src/views/team/i18n/en-US.json
@@ -1,8 +1,8 @@
 {
   "meta": {
-    "title": "Our Team"
+    "title": "Our Team",
+    "description": "Developing the robustness and resilience of territories in the face of climate change."
   },
-  "header_subtitle": "Developing the robustness and resilience of territories in the face of climate change.",
   "team_section": {
     "title": "The Lychen Team",
     "description": "We are a team dedicated to creating an open-source digital ecosystem. Our mission: to connect citizens, producers, associations, and local authorities to promote sustainable agriculture and biodiversity protection.",

--- a/projects/website/src/views/team/i18n/fr-FR.json
+++ b/projects/website/src/views/team/i18n/fr-FR.json
@@ -1,8 +1,8 @@
 {
   "meta": {
-    "title": "Notre équipe"
+    "title": "Notre équipe",
+    "description": "Développer la robustesse et la résilience des territoires face aux changements climatiques."
   },
-  "header_subtitle": "Développer la robustesse et la résilience des territoires face aux changements climatiques.",
   "team_section": {
     "title": "L'équipe Lychen",
     "description": "Nous sommes une équipe dédiée à la création d'un écosystème numérique open-source. Notre mission : connecter citoyens, producteurs, associations et collectivités pour favoriser une agriculture durable et la protection de la biodiversité."

--- a/projects/website/src/views/team/i18n/fr-FR.json
+++ b/projects/website/src/views/team/i18n/fr-FR.json
@@ -1,5 +1,7 @@
 {
-  "title": "Notre équipe",
+  "meta": {
+    "title": "Notre équipe"
+  },
   "header_subtitle": "Développer la robustesse et la résilience des territoires face aux changements climatiques.",
   "team_section": {
     "title": "L'équipe Lychen",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced i18n: page titles and metadata now driven by translations for Home, Charter, Mission, and Team pages
  * Document language attribute now updates dynamically with the selected locale
  * Home page title simplified to "Food Autonomy Collective"

* **Chores**
  * Page metadata keys consolidated under a unified meta structure for consistent localization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->