### PR TITLE
fix(espace-website): stack subtitle and CTA vertically on mobile

### DIFF
--- a/projects/espace/website/src/views/home/View.vue
+++ b/projects/espace/website/src/views/home/View.vue
@@ -42,7 +42,7 @@
   </Container>
   <Container class="flex flex-col items-start justify-center gap-8">
     <Title variant="h1">{{ t('search.title') }}</Title>
-    <div class="flex flex-row items-center gap-2">
+    <div class="flex flex-col items-start gap-2 md:flex-row md:items-center">
       <Paragraph>{{ t('search.subtitle') }}</Paragraph>
       <a
         :href="LINK.LandRequestForm"


### PR DESCRIPTION
## Summary

- Fixes mobile layout in the search section of the Espace website home page
- The subtitle paragraph and CTA button were displayed side-by-side (`flex-row`) on all screen sizes
- Changed to `flex-col items-start` on mobile so content stacks vertically: **title → text → button**
- Reverts to the horizontal `md:flex-row md:items-center` layout on medium+ breakpoints

## Files changed

- `projects/espace/website/src/views/home/View.vue` — one-line Tailwind class adjustment

## Test plan

- [ ] Open the Espace website home page on a mobile viewport (< 768px)
- [ ] Verify the search section shows: title on top, subtitle text below it, then the CTA button below the text
- [ ] Verify no regression on desktop (md+): subtitle and button are still side by side

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGarLxNojZruP6THxugVet)_