### PR TITLE
fix(espace-website): stack search section content vertically on mobile

### DIFF
--- a/projects/espace/website/src/views/home/View.vue
+++ b/projects/espace/website/src/views/home/View.vue
@@ -42,7 +42,7 @@
   </Container>
   <Container class="flex flex-col items-start justify-center gap-8">
     <Title variant="h1">{{ t('search.title') }}</Title>
-    <div class="flex flex-col items-start gap-2 md:flex-row md:items-center">
+    <div class="flex flex-col items-start gap-2 lg:flex-row lg:items-center">
       <Paragraph>{{ t('search.subtitle') }}</Paragraph>
       <a
         :href="LINK.LandRequestForm"
@@ -53,7 +53,7 @@
         ></Button>
       </a>
     </div>
-    <div class="flex w-1/3 flex-row items-center gap-2 opacity-20">
+    <div class="flex w-full flex-row items-center gap-2 opacity-20 lg:w-1/3">
       <Popover>
         <PopoverTrigger as-child>
           <Button


### PR DESCRIPTION
## Summary

- Change subtitle + CTA breakpoint from `md` (768px) to `lg` (1024px) in the search section so the **title → text → button** layout stays stacked vertically on mobile and small tablets
- Fix the search bar container width: replace the fixed `w-1/3` (too narrow on mobile) with `w-full lg:w-1/3` so it uses full width on small screens

## What changed

In `projects/espace/website/src/views/home/View.vue`:

| Before | After |
|--------|-------|
| `md:flex-row md:items-center` | `lg:flex-row lg:items-center` |
| `flex w-1/3 flex-row …` | `flex w-full flex-row … lg:w-1/3` |

## Test plan

- [ ] Open the espace website on a mobile viewport (< 1024px) and verify the search section displays as: title → subtitle text → CTA button (all stacked vertically)
- [ ] Verify on desktop (≥ 1024px) the subtitle and CTA button are displayed side-by-side as before
- [ ] Verify the search bar is full-width on mobile and one-third width on desktop

---
_Generated by [Claude Code](https://claude.ai/code/session_0116Y8Ju91caVb97EFZqpUpS)_