### PR TITLE
fix(espace-website): stack search section subtitle and CTA vertically on mobile

### DIFF
--- a/projects/espace/website/src/views/home/View.vue
+++ b/projects/espace/website/src/views/home/View.vue
@@ -42,7 +42,7 @@
   </Container>
   <Container class="flex flex-col items-start justify-center gap-8">
     <Title variant="h1">{{ t('search.title') }}</Title>
-    <div class="flex flex-col items-start gap-2 md:flex-row md:items-center">
+    <div class="flex flex-col items-start gap-2 lg:flex-row lg:items-center">
       <Paragraph>{{ t('search.subtitle') }}</Paragraph>
       <a
         :href="LINK.LandRequestForm"


### PR DESCRIPTION
## Summary

- Fixes the mobile display of the search section on the Espace website homepage
- The subtitle text and CTA button were displayed side-by-side at the `md` breakpoint (768px), which affects many tablets and larger mobile devices
- Changed the flex-row breakpoint from `md` (768px) to `lg` (1024px), ensuring the layout stays vertical (`title → text → button`) on all mobile and tablet screens

## Changes

**`projects/espace/website/src/views/home/View.vue`**

```diff
- <div class="flex flex-col items-start gap-2 md:flex-row md:items-center">
+ <div class="flex flex-col items-start gap-2 lg:flex-row lg:items-center">
```

## Test plan

- [ ] Open the Espace website homepage on a mobile device (< 1024px width)
- [ ] Verify the search section shows: title → subtitle text → CTA button, all stacked vertically
- [ ] Verify the layout still goes horizontal on desktop (≥ 1024px)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SuiGLkBmiKh3kkyQL7QyxF)_