### PR TITLE
fix(espace-website): improve hero section mobile layout

### DIFF
--- a/projects/espace/website/src/views/home/View.vue
+++ b/projects/espace/website/src/views/home/View.vue
@@ -14,28 +14,26 @@
         <div
           class="bg-surface-container/70 z-10 flex w-full flex-col items-start gap-4 rounded-2xl px-8 py-10 backdrop-blur-md lg:w-1/3"
         >
-          <IconHeartHandshake class="size-18!" />
+          <IconHeartHandshake class="hidden size-18! lg:block" />
           <h2 class="text-on-white text-xl font-bold">
             {{ t('hero.description') }}
           </h2>
-          <div class="flex flex-col items-start gap-2">
+          <p class="text-xs opacity-80">
+            {{ t('hero.email_prefix') }}
             <a
-              :href="LINK.LandProposalForm"
-              target="_blank"
+              href="mailto:contact@lychen.org"
+              class="underline"
+              >contact@lychen.org</a
             >
-              <Button size="lg"
-                >{{ t('hero.cta_share') }} <template #icon><IconArrowRight /></template
-              ></Button>
-            </a>
-            <p class="text-xs opacity-80">
-              {{ t('hero.email_prefix') }}
-              <a
-                href="mailto:contact@lychen.org"
-                class="underline"
-                >contact@lychen.org</a
-              >
-            </p>
-          </div>
+          </p>
+          <a
+            :href="LINK.LandProposalForm"
+            target="_blank"
+          >
+            <Button size="lg"
+              >{{ t('hero.cta_share') }} <template #icon><IconArrowRight /></template
+            ></Button>
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Hide the decorative icon on mobile so it doesn't push content down
- Reorder hero section content to follow the expected vertical flow on mobile: **title → text → button**
- Remove the unnecessary wrapper `<div>` grouping button and email text

## Changes

**File:** `projects/espace/website/src/views/home/View.vue`

- `IconHeartHandshake`: added `hidden lg:block` — icon is hidden on mobile, visible on desktop
- Moved email helper text (`<p>`) above the CTA button to match the desired order
- Flattened the button/text wrapper div — elements are now direct siblings in the content card

## Test plan

- [ ] View on a mobile viewport (< 1024px): icon should be hidden, content should flow title → text → button
- [ ] View on desktop (≥ 1024px): icon should be visible, layout unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_018Rp88DkAJGuRrvAV8iouc3)_