### PR TITLE
ci(frontend): add lint & format quality workflow + fix undeclared api-sdk dependency

### DIFF
--- a/.github/workflows/frontend-quality.yml
+++ b/.github/workflows/frontend-quality.yml
@@ -1,0 +1,29 @@
+name: 'Frontend | Quality'
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-format:
+    name: 'Lint & Format affected projects'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 'actions/checkout@v4'
+        with:
+          fetch-depth: 0
+
+      - name: Set up Moon Toolchain
+        uses: 'moonrepo/setup-toolchain@v0'
+
+      - name: Install proto tools
+        run: proto install
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Lint and check formatting
+        run: moon ci :lint :format

--- a/projects/tera/app/moon.yml
+++ b/projects/tera/app/moon.yml
@@ -1,6 +1,7 @@
 dependsOn:
   - css-core
   - i18n-tera
+  - typescript-tera-api-sdk
   - typescript-tera-core
   - typescript-zitadel
   - vue-color-scheme

--- a/projects/tera/app/package.json
+++ b/projects/tera/app/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@lychen/css-core": "workspace:*",
     "@lychen/i18n-tera": "workspace:*",
+    "@lychen/typescript-tera-api-sdk": "workspace:*",
     "@lychen/typescript-tera-core": "workspace:*",
     "@lychen/typescript-zitadel": "workspace:*",
     "@lychen/vue-color-scheme": "workspace:*",

--- a/projects/tera/app/tsconfig.json
+++ b/projects/tera/app/tsconfig.json
@@ -6,6 +6,9 @@
       "path": "../../../libs/i18n/tera"
     },
     {
+      "path": "../../../libs/typescript/tera/api-sdk"
+    },
+    {
       "path": "../../../libs/typescript/tera/core"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2403,6 +2403,7 @@ __metadata:
   dependencies:
     "@lychen/css-core": "workspace:*"
     "@lychen/i18n-tera": "workspace:*"
+    "@lychen/typescript-tera-api-sdk": "workspace:*"
     "@lychen/typescript-tera-core": "workspace:*"
     "@lychen/typescript-zitadel": "workspace:*"
     "@lychen/vue-color-scheme": "workspace:*"


### PR DESCRIPTION
## What

- New workflow `.github/workflows/frontend-quality.yml`: on every `pull_request`, runs `moon ci :lint :format` in a single job. `moon ci` auto-detects affected projects from the diff, so only touched projects are linted/format-checked. Setup mirrors the existing `quality.yml` (checkout with `fetch-depth: 0`, `moonrepo/setup-toolchain@v0`, `proto install`, `corepack enable`, same concurrency group).
- Declares the previously undeclared `@lychen/typescript-tera-api-sdk` dependency of `tera-app`:
  - `projects/tera/app/package.json`: added `"@lychen/typescript-tera-api-sdk": "workspace:*"` (alphabetical order kept).
  - `projects/tera/app/moon.yml`: added `typescript-tera-api-sdk` to `dependsOn` (alphabetical order kept).
  - `projects/tera/app/tsconfig.json`: project reference added automatically by moon's `syncProjectReferences`.
- Refreshes `yarn.lock` (yarn 4.12.0, the pinned version).

## Why

- Today nothing in CI enforces ESLint/Prettier for the frontend — the only gate is the local pre-commit hook, which is bypassable (`--no-verify`).
- `tera-app` imports `@lychen/typescript-tera-api-sdk` in `src/pages/lands/PageLands.vue` and `src/pages/land/tasks/PageLandTasks.vue` but never declared it; it only resolved through Yarn hoisting, and moon's task/dependency graph was unaware of it.
- About the large `yarn.lock` diff: it is almost entirely **pre-existing drift on `main`**, not caused by the one-line dependency addition. Verified: on a pristine checkout of `main` (1f2430ff), `yarn install` with the pinned yarn 4.12.0 already rewrites ~4,500 lockfile lines, and `yarn install --immutable` fails with `YN0028: The lockfile would have been modified by this install`. Since yarn auto-enables immutable installs in CI, the new workflow (and any future CI install) would fail without this refresh. After the refresh, `yarn install --immutable` passes.

## How to verify

- `yarn install --immutable` → passes (fails on current `main`).
- `moon run tera-app:lint tera-app:format` → both pass locally.
- `moon project tera-app` → lists `typescript-tera-api-sdk (production)` under "Depends on".
- `moon ci --help` → confirms `moon ci [TARGETS]...` accepts explicit targets as used in the workflow.
- The workflow run on this very PR exercises the new job end to end.

## Not verified locally / caveats

- The GitHub Actions run itself (runner environment, `moonrepo/setup-toolchain@v0` behavior on a fresh runner) could not be executed locally — the run on this PR is the real test.
- **Possible `yarn.lock` / root `package.json` conflicts** with the sibling PRs of this series (vitest and vue-tsc PRs touch root `package.json`/`yarn.lock`). Whichever merges last should re-run `yarn install` and refresh the lockfile.
- Follow-up idea (deliberately not included): enabling `import/no-extraneous-dependencies` in `eslint.config.js` would catch undeclared dependencies like this one automatically, but in this 56-package workspace it needs careful per-package `packageDir` configuration to avoid false positives, so it was left out rather than shipped unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)