### PR TITLE
chore(deps): add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":semanticCommits"],
+  "timezone": "Europe/Paris",
+  "schedule": ["before 6am on monday"],
+  "prConcurrentLimit": 5,
+  "dependencyDashboard": true,
+  "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "packageRules": [
+    {
+      "description": "Internal workspace packages are managed by the monorepo, never by Renovate",
+      "matchPackageNames": ["@lychen/**", "lychen/**"],
+      "enabled": false
+    },
+    {
+      "description": "Group Vue ecosystem (Vue, Router, Vite and its plugins, vue-tsc)",
+      "groupName": "vue ecosystem",
+      "matchPackageNames": [
+        "vue",
+        "vue-router",
+        "vue-tsc",
+        "vite",
+        "vite-**",
+        "@vitejs/**",
+        "@vite-pwa/**",
+        "@vue/**"
+      ],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group Tailwind CSS and styling utilities",
+      "groupName": "tailwind",
+      "matchPackageNames": [
+        "tailwindcss",
+        "@tailwindcss/**",
+        "tailwind-merge",
+        "class-variance-authority"
+      ],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group Tanstack packages (Query, Table)",
+      "groupName": "tanstack",
+      "matchPackageNames": ["@tanstack/**"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group lint and format tooling",
+      "groupName": "lint and format tooling",
+      "matchPackageNames": [
+        "eslint",
+        "eslint-**",
+        "@eslint/**",
+        "@types/eslint",
+        "vue-eslint-parser",
+        "typescript-eslint",
+        "prettier",
+        "prettier-**",
+        "globals"
+      ],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group Reka UI / shadcn-vue related UI primitives",
+      "groupName": "reka ui",
+      "matchPackageNames": ["reka-ui", "vaul-vue", "embla-carousel-**"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group all Composer (Symfony APIs) updates into a single weekly PR",
+      "groupName": "composer packages",
+      "matchManagers": ["composer"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "groupName": "github actions",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a `renovate.json` at the repo root so dependency updates are handled by [Renovate](https://docs.renovatebot.com/) instead of manual big-bang bumps.

## Why

Recent dependency updates have been large manual PRs ("bump all outdated npm dependencies", "bump toolchain and package dependencies across monorepo") that touch dozens of packages at once and are hard to review and bisect. Renovate replaces these with continuous, small, scoped PRs that CI can validate individually — regressions become attributable to a single group instead of an entire upgrade sweep.

## Groups & schedule

- **Schedule:** weekly, before 6am on Monday (Europe/Paris), max 5 concurrent PRs.
- **Commits/PR titles:** semantic, `chore(deps): ...`, matching existing repo history.
- **Grouped (minor + patch) PRs:**
  - `vue ecosystem` — vue, vue-router, vue-tsc, vite, vite-* plugins, @vitejs/*, @vite-pwa/*, @vue/*
  - `tailwind` — tailwindcss, @tailwindcss/*, tailwind-merge, class-variance-authority
  - `tanstack` — @tanstack/* (Query, Table)
  - `lint and format tooling` — eslint*, @eslint/*, prettier*, typescript-eslint, vue-eslint-parser, globals
  - `reka ui` — reka-ui, vaul-vue, embla-carousel-*
  - `composer packages` — all Symfony API composer.json files (incl. each project's `tools/composer.json`)
  - `github actions` — workflow action versions
- **Major updates:** always separate PRs (groups are restricted to minor/patch), tracked via the Dependency Dashboard issue.
- **`rangeStrategy: bump`:** keeps the existing caret (`^`) range style while also updating the manifests for in-range releases — with `replace`, package.json would only change when a release falls outside the current range, leaving manifests stale. `bump` mirrors the repo's current practice of keeping declared versions current.
- **Lock file maintenance:** weekly refresh of `yarn.lock` / `composer.lock` for transitive deps.
- **Internal packages:** `@lychen/*` (workspace) and `lychen/*` (composer path repos) are excluded.
- **Toolchain:** Renovate's built-in `proto` manager covers `.prototools` (node, yarn, npm, moon), so toolchain versions are updated too.

## Action required

The **Renovate GitHub App must be installed** on `lychen-lab/lychen` for this configuration to take effect: https://github.com/apps/renovate

Note: the value of this setup compounds once the CI quality gates (sibling PRs of this series) are merged — Renovate PRs are only as safe as the checks that gate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)