### PR TITLE
test(frontend): add Vitest infrastructure with moon test task and first unit tests

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,32 @@
+name: 'Frontend | Tests'
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    name: 'Run unit tests'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 'actions/checkout@v4'
+        with:
+          fetch-depth: 0
+
+      - name: Set up Moon Toolchain
+        uses: 'moonrepo/setup-toolchain@v0'
+
+      - name: Install proto tools
+        run: proto install
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Run unit tests
+        run: moon ci :test

--- a/.moon/tasks/frontend.yml
+++ b/.moon/tasks/frontend.yml
@@ -36,5 +36,17 @@ tasks:
     - args:
       - --fix
       target: lint
+  test:
+    command:
+    - vitest
+    - run
+    - --passWithNoTests
+    inputs:
+    - '**/*.{vue,ts,js}'
+    - '!**/build/'
+    - '!**/dist/'
+    - '!**/vendor/'
+    - '!**/playwright-report/'
+    - '!**/.vite-ssg-temp/'
 inheritedBy:
   stack: frontend

--- a/libs/typescript/utils/moon.yml
+++ b/libs/typescript/utils/moon.yml
@@ -1,3 +1,4 @@
 id: typescript-utils
 language: typescript
 layer: library
+stack: frontend

--- a/libs/typescript/utils/tailwind/Cn.test.ts
+++ b/libs/typescript/utils/tailwind/Cn.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { cn } from './Cn';
+
+describe('cn', () => {
+  it('returns an empty string when called without arguments', () => {
+    expect(cn()).toBe('');
+  });
+
+  it('concatenates independent class names', () => {
+    expect(cn('px-2', 'py-4')).toBe('px-2 py-4');
+  });
+
+  it('keeps the last class when Tailwind classes conflict', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4');
+    expect(cn('text-sm', 'text-lg')).toBe('text-lg');
+  });
+
+  it('does not merge classes from different Tailwind groups', () => {
+    expect(cn('text-sm', 'text-red-500')).toBe('text-sm text-red-500');
+  });
+
+  it('ignores falsy values', () => {
+    expect(cn('flex', undefined, null, false, '')).toBe('flex');
+  });
+
+  it('handles conditional classes provided as objects', () => {
+    expect(cn({ flex: true, hidden: false }, 'gap-2')).toBe('flex gap-2');
+  });
+
+  it('flattens nested arrays of classes', () => {
+    expect(cn(['flex', ['items-center', ['justify-between']]])).toBe(
+      'flex items-center justify-between',
+    );
+  });
+
+  it('resolves conflicts across mixed input shapes', () => {
+    expect(cn('p-2', { 'p-4': true }, ['p-8'])).toBe('p-8');
+  });
+});

--- a/libs/typescript/utils/transformers/ObjectValues.test.ts
+++ b/libs/typescript/utils/transformers/ObjectValues.test.ts
@@ -1,0 +1,21 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { ObjectValues } from './ObjectValues';
+
+const PLANT_STATUS = {
+  Dormant: 'dormant',
+  Growing: 'growing',
+} as const;
+
+describe('ObjectValues', () => {
+  it('produces the union of the literal value types of a const object', () => {
+    expectTypeOf<ObjectValues<typeof PLANT_STATUS>>().toEqualTypeOf<'dormant' | 'growing'>();
+  });
+
+  it('resolves to the value type of a uniform record', () => {
+    expectTypeOf<ObjectValues<Record<string, number>>>().toEqualTypeOf<number>();
+  });
+
+  it('produces a union across heterogeneous value types', () => {
+    expectTypeOf<ObjectValues<{ id: number; name: string }>>().toEqualTypeOf<number | string>();
+  });
+});

--- a/libs/typescript/utils/transformers/extractValuesByKey.test.ts
+++ b/libs/typescript/utils/transformers/extractValuesByKey.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { extractValuesByKey } from './extractValuesByKey';
+
+interface Plant {
+  id: number;
+  name: string;
+  family?: string;
+}
+
+describe('extractValuesByKey', () => {
+  it('extracts the values of the given key from every item', () => {
+    const plants: Plant[] = [
+      { id: 1, name: 'Oak', family: 'Fagaceae' },
+      { id: 2, name: 'Clover', family: 'Fabaceae' },
+    ];
+
+    expect(extractValuesByKey(plants, 'name')).toEqual(['Oak', 'Clover']);
+    expect(extractValuesByKey(plants, 'id')).toEqual([1, 2]);
+  });
+
+  it('returns an empty array for an empty list', () => {
+    expect(extractValuesByKey([] as Plant[], 'name')).toEqual([]);
+  });
+
+  it('preserves the order and duplicates of the source list', () => {
+    const plants: Plant[] = [
+      { id: 3, name: 'Moss' },
+      { id: 1, name: 'Lichen' },
+      { id: 3, name: 'Moss' },
+    ];
+
+    expect(extractValuesByKey(plants, 'id')).toEqual([3, 1, 3]);
+  });
+
+  it('keeps undefined slots for items missing an optional key', () => {
+    const plants: Plant[] = [
+      { id: 1, name: 'Oak', family: 'Fagaceae' },
+      { id: 2, name: 'Moss' },
+    ];
+
+    expect(extractValuesByKey(plants, 'family')).toEqual(['Fagaceae', undefined]);
+  });
+
+  it('keeps references to extracted object values', () => {
+    const coordinates = { lat: 45.76, lng: 4.83 };
+    const list = [{ position: coordinates }];
+
+    const result = extractValuesByKey(list, 'position');
+
+    expect(result[0]).toBe(coordinates);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "tsconfig-moon": "^1.4.2",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.1",
+    "vitest": "^4.1.8",
     "vue-eslint-parser": "^10.4.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4144,6 +4144,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@standard-schema/spec@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@standard-schema/spec@npm:1.1.0"
+  checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
+  languageName: node
+  linkType: hard
+
 "@storybook/addon-a11y@npm:^10.4.2":
   version: 10.4.4
   resolution: "@storybook/addon-a11y@npm:10.4.4"
@@ -5317,12 +5324,76 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/expect@npm:4.1.8"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:4.1.8"
+    "@vitest/utils": "npm:4.1.8"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/f7bf6c720d2427c3bd0b35472ebd84d963be7d09ecf52a0fb05e8c4d5d0c9ee164a8c28eee6360947be1b245b47faefab54560cb98e5cb678c1c1074260b9149
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/mocker@npm:4.1.8"
+  dependencies:
+    "@vitest/spy": "npm:4.1.8"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.21"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/f8cb2b8b55dc2cba0b2399aeee528b0187042f22cbc2d50a4fd6141f5aa246ebc41700f45dd1d73eca44ddfb57dcde48b2eb317bfbb1198f5ab2cc4fd04b2ea0
+  languageName: node
+  linkType: hard
+
 "@vitest/pretty-format@npm:3.2.4":
   version: 3.2.4
   resolution: "@vitest/pretty-format@npm:3.2.4"
   dependencies:
     tinyrainbow: "npm:^2.0.0"
   checksum: 10c0/5ad7d4278e067390d7d633e307fee8103958806a419ca380aec0e33fae71b44a64415f7a9b4bc11635d3c13d4a9186111c581d3cef9c65cc317e68f077456887
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/pretty-format@npm:4.1.8"
+  dependencies:
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/553c456692a4b9ae13cd116c234c74b4495e0f1a0d5c51ffc3fab8ea085e3550769967e29db79bdac0cf127b1bf88b7f70bfba3dcc72be6bddf834433e30cc91
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/runner@npm:4.1.8"
+  dependencies:
+    "@vitest/utils": "npm:4.1.8"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/706808a4b7b95ea9a9268fc152dd39e15a9a754f37c7990aea167486a9094caa913dae454771ae02c18dccfabd667f8cc38eed33a1307a79d32a89878b5bcce1
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/snapshot@npm:4.1.8"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.8"
+    "@vitest/utils": "npm:4.1.8"
+    magic-string: "npm:^0.30.21"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/ba4c32112491d42d24986f921c50ede5edbdb4b7eafa16c72cf8d2c9ecc44121fdb3d9365236747a9841f0d6776affc6457470fcbb082df9dbc28c24792a0c6d
   languageName: node
   linkType: hard
 
@@ -5335,6 +5406,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/spy@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/spy@npm:4.1.8"
+  checksum: 10c0/3c10c0325a09d16bc0e77c0be96c47c15416186e33332880c0d1dd0a51d51a866091067b81f2a2ef6fb422a7760e6cf15c04d91a0eca4d59f62e8c8401fa53fc
+  languageName: node
+  linkType: hard
+
 "@vitest/utils@npm:3.2.4":
   version: 3.2.4
   resolution: "@vitest/utils@npm:3.2.4"
@@ -5343,6 +5421,17 @@ __metadata:
     loupe: "npm:^3.1.4"
     tinyrainbow: "npm:^2.0.0"
   checksum: 10c0/024a9b8c8bcc12cf40183c246c244b52ecff861c6deb3477cbf487ac8781ad44c68a9c5fd69f8c1361878e55b97c10d99d511f2597f1f7244b5e5101d028ba64
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.1.8":
+  version: 4.1.8
+  resolution: "@vitest/utils@npm:4.1.8"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.8"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/acda9d3d640c1ebc81afb358ac30589d7d7d583af81e2d09419f0af9cbe41f3ce0b90527326943bf0da51614be5fc31afcd32259f6beb32b3417999d6ef380f3
   languageName: node
   linkType: hard
 
@@ -6545,6 +6634,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^4.0.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -7373,6 +7469,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "es-module-lexer@npm:2.1.0"
+  checksum: 10c0/93bcf2454fa72d67fe3ccd0abef8ce7933f5840a319513418a643dd8e9c6aa8f49709cecfae02ded722805dd327232d30723a807cc52e6809d6ac697c62c29fb
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
   version: 1.1.1
   resolution: "es-object-atoms@npm:1.1.1"
@@ -7830,6 +7933,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -7841,6 +7953,13 @@ __metadata:
   version: 4.6.0
   resolution: "eta@npm:4.6.0"
   checksum: 10c0/98c8081f756884bbc22f2bf4a6a38c2322ee97575fb6f0c02dcb1c3040353971c91a96bfba2d6f7cba39bb0ebece5708803a765447d9a81ca1172ccd5e31becf
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "expect-type@npm:1.3.0"
+  checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
   languageName: node
   linkType: hard
 
@@ -9392,6 +9511,7 @@ __metadata:
     tsconfig-moon: "npm:^1.4.2"
     typescript: "npm:^6.0.3"
     typescript-eslint: "npm:^8.60.1"
+    vitest: "npm:^4.1.8"
     vue-eslint-parser: "npm:^10.4.0"
   languageName: unknown
   linkType: soft
@@ -10364,6 +10484,13 @@ __metadata:
     define-properties: "npm:^1.2.1"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10c0/3c47814fdc64842ae3d5a74bc9d06bdd8d21563c04d9939bf6716a9c00596a4ebc342552f8934013d1ec991c74e3671b26710a0c51815f0b603795605ab6b2c9
+  languageName: node
+  linkType: hard
+
+"obug@npm:^2.1.1":
+  version: 2.1.3
+  resolution: "obug@npm:2.1.3"
+  checksum: 10c0/cb8187fed0a5fc8445507c950e89f3c1bd43895658c398b5803f6b7804dfa0c562975ecce1e67f3d9247d521452a5bfade9e0e951cc0326b7444272f7c24d25f
   languageName: node
   linkType: hard
 
@@ -12170,6 +12297,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^4.0.1":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
@@ -12294,6 +12428,20 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/caddd5f544b2006e88fa6b0124d8d7b28208b83c72d7672d5ade44d794525d23b540f3396108c4eb9280dcb7c01f0bef50682f5b4b2c34291f7c5e211fd1417d
+  languageName: node
+  linkType: hard
+
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^4.0.0-rc.1":
+  version: 4.1.0
+  resolution: "std-env@npm:4.1.0"
+  checksum: 10c0/2e14b6b490db34cb969a48d9cf7c35bca4a47653914aac2814221baae7b867a5b15940d133625c391621971f98cd2266a5dc7036669960e883f1081db2a56558
   languageName: node
   linkType: hard
 
@@ -12641,7 +12789,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^1.2.2, tinyexec@npm:^1.2.4":
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^1.0.2, tinyexec@npm:^1.2.2, tinyexec@npm:^1.2.4":
   version: 1.2.4
   resolution: "tinyexec@npm:1.2.4"
   checksum: 10c0/153b8db6b080194b558ff145b9cffc36b80a6e07babd644dcfbe49c807eee668c876049d28bdee90b96304476f883352f2dad91b3f86bc23832532f4363e66ff
@@ -12672,6 +12827,13 @@ __metadata:
   version: 2.0.0
   resolution: "tinyrainbow@npm:2.0.0"
   checksum: 10c0/c83c52bef4e0ae7fb8ec6a722f70b5b6fa8d8be1c85792e829f56c0e1be94ab70b293c032dc5048d4d37cfe678f1f5babb04bdc65fd123098800148ca989184f
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "tinyrainbow@npm:3.1.0"
+  checksum: 10c0/f11cf387a26c5c9255bec141a90ac511b26172981b10c3e50053bc6700ea7d2336edcc4a3a21dbb8412fe7c013477d2ba4d7e4877800f3f8107be5105aad6511
   languageName: node
   linkType: hard
 
@@ -13452,7 +13614,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^8.0.16":
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0, vite@npm:^8.0.16":
   version: 8.0.16
   resolution: "vite@npm:8.0.16"
   dependencies:
@@ -13506,6 +13668,74 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/d75be3fbe2f63e6a8145325970338afaf0dd4d96ba9175c13f9a286fd5f95afc489401b693e4fa6c0899a4dd0e137be91cdf9401a40a635563911ad5036e3467
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^4.1.8":
+  version: 4.1.8
+  resolution: "vitest@npm:4.1.8"
+  dependencies:
+    "@vitest/expect": "npm:4.1.8"
+    "@vitest/mocker": "npm:4.1.8"
+    "@vitest/pretty-format": "npm:4.1.8"
+    "@vitest/runner": "npm:4.1.8"
+    "@vitest/snapshot": "npm:4.1.8"
+    "@vitest/spy": "npm:4.1.8"
+    "@vitest/utils": "npm:4.1.8"
+    es-module-lexer: "npm:^2.0.0"
+    expect-type: "npm:^1.3.0"
+    magic-string: "npm:^0.30.21"
+    obug: "npm:^2.1.1"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.3"
+    std-env: "npm:^4.0.0-rc.1"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^1.0.2"
+    tinyglobby: "npm:^0.2.15"
+    tinyrainbow: "npm:^3.1.0"
+    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 4.1.8
+    "@vitest/browser-preview": 4.1.8
+    "@vitest/browser-webdriverio": 4.1.8
+    "@vitest/coverage-istanbul": 4.1.8
+    "@vitest/coverage-v8": 4.1.8
+    "@vitest/ui": 4.1.8
+    happy-dom: "*"
+    jsdom: "*"
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
+      optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    vite:
+      optional: false
+  bin:
+    vitest: vitest.mjs
+  checksum: 10c0/f459c500f8818c7a2318cd23228b4e5c0b5efb25bf8e5cb7f116c6d26e51482b2f800a8bb19837c0b5f0d05c51519edbf502bc8ceb5bd86868e8facf1d2c498e
   languageName: node
   linkType: hard
 
@@ -13876,6 +14106,18 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/e556e4cd8b7dbf5df52408c9a9dd5ac6518c8c5267c8953f5b0564073c66ed5bf9503b14d876d0e9c7844d4db9725fb0dcf45d6e911e17e26ab363dc3965ae7b
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

- Add `vitest` (`^4.1.8`) to the root `package.json` devDependencies and update `yarn.lock`.
- Add a `test` task to `.moon/tasks/frontend.yml` (`vitest run --passWithNoTests`), inherited by every `stack: frontend` project, with input globs matching the sibling `lint`/`format` tasks.
- Declare `stack: frontend` on `typescript-utils` (`libs/typescript/utils/moon.yml`) so the library inherits the frontend task set — it previously had `Stack: unknown` and inherited no tasks at all (this also gives it `lint`/`format`, both verified passing).
- First unit tests covering all three exports of `@lychen/typescript-utils`:
  - `tailwind/Cn.test.ts` — class concatenation, Tailwind conflict resolution, falsy/object/nested-array inputs, mixed shapes.
  - `transformers/extractValuesByKey.test.ts` — extraction, empty list, order/duplicates, optional-key behavior, reference identity.
  - `transformers/ObjectValues.test.ts` — type-level assertions via `expectTypeOf`.
- New CI workflow `.github/workflows/frontend-tests.yml`: `pull_request` trigger, concurrency group, `moonrepo/setup-toolchain@v0`, `proto install`, `corepack enable`, `yarn install`, `moon ci :test` (mirrors `quality.yml`).

## Why

The repository had zero unit tests and no test runner for the frontend stack. This sets up the shared infrastructure (one root dependency, one inherited Moon task, one CI workflow) so any frontend project or library can add `*.test.ts` files and have them run locally and in CI with no further wiring. `--passWithNoTests` keeps the task green for projects that have no tests yet.

## Verification

Ran locally via Moon (no proto/yarn plugin mismatch encountered):

```
$ moon run typescript-utils:test
 RUN  v4.1.8 libs/typescript/utils
 Test Files  3 passed (3)
      Tests  16 passed (16)
   Duration  120ms

$ moon run :test
Tasks: 8 completed   # 7 frontend apps with no tests exit 0 via --passWithNoTests
```

Also verified: `moon run typescript-utils:lint` and `typescript-utils:format` pass, the new test files typecheck under TS strict + `noUncheckedIndexedAccess`, and `yarn install --immutable` succeeds on the updated lockfile.

Note on the `yarn.lock` diff size: the lockfile on `main` was stale relative to the dependency ranges bumped in #119 (e.g. `@eslint/markdown@^8.0.2` had no lock entry), so `yarn install` re-resolved those pending ranges in addition to adding vitest. `yarn install --immutable` failed on `main` and passes on this branch.

## Follow-ups

- Component testing: add `@vue/test-utils` + `jsdom` (or `happy-dom`) and a shared Vitest config for the `libs/vue/*` component libraries.
- Playwright CI: wiring the existing `tera-tests-e2e` suite into CI is intentionally out of scope — it requires infra/secrets decisions (Zitadel auth, local domains).
- Other `libs/typescript/*` and `libs/vue/*` libraries currently have `Stack: unknown` and inherit no Moon tasks (not even `lint`/`format`); declaring `stack: frontend` on them as done here for `typescript-utils` would onboard them to test/lint/format.

## Possible conflicts

- `.moon/tasks/frontend.yml` is also touched by the in-flight typecheck PR.
- Root `package.json` / `yarn.lock` will conflict with any sibling PR touching dependencies; regenerate the lockfile on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)