### PR TITLE
perf(moon): enable caching for frontend build tasks

### DIFF
--- a/.moon/tasks/tag-pwa.yml
+++ b/.moon/tasks/tag-pwa.yml
@@ -6,8 +6,31 @@ tasks:
     - args:
       - $projectRoot/.nginx-build
       target: nginx-configs:sync-pwa
-    options:
-      cache: false
+    inputs:
+    - .env*
+    - index.html
+    - package.json
+    - public/**/*
+    - src/**/*
+    - tsconfig.json
+    - vite.config.ts
+    - /libs/css/**/*
+    - /libs/drawio/**/*
+    - /libs/i18n/**/*
+    - /libs/typescript/**/*
+    - /libs/vite/**/*
+    - /libs/vue/**/*
+    - /yarn.lock
+    - project://^
+    - $APP_ID
+    - $ESPACE_API_HOST
+    - $HOST
+    - $VITE_*
+    - $ZITADEL_CLIENT_ID
+    - $ZITADEL_ISSUER
+    - $ZITADEL_PROJECT_RESOURCE_ID
+    outputs:
+    - dist
   dev:
     command: yarn dev
     options:

--- a/.moon/tasks/tag-ssg.yml
+++ b/.moon/tasks/tag-ssg.yml
@@ -8,8 +8,28 @@ tasks:
     - args:
       - $projectRoot/.nginx-build
       target: nginx-configs:sync-ssg
-    options:
-      cache: false
+    inputs:
+    - .env*
+    - index.html
+    - package.json
+    - public/**/*
+    - src/**/*
+    - tsconfig.json
+    - vite.config.ts
+    - /libs/css/**/*
+    - /libs/drawio/**/*
+    - /libs/i18n/**/*
+    - /libs/typescript/**/*
+    - /libs/vite/**/*
+    - /libs/vue/**/*
+    - /yarn.lock
+    - project://^
+    - $APP_ID
+    - $ESPACE_WEBSITE_HOST
+    - $HOST
+    - $VITE_*
+    outputs:
+    - dist
   dev:
     command: yarn dev
     env:


### PR DESCRIPTION
## What

Removes `options.cache: false` from the `build` tasks in `.moon/tasks/tag-pwa.yml` and `.moon/tasks/tag-ssg.yml`, and declares explicit `inputs` + `outputs: ['dist']` so Moon can cache frontend builds and hydrate `dist` from the cache when nothing relevant changed.

Affected projects: `tera-app`, `espace-app` (pwa) and `website`, `tera-website`, `espace-website`, `robust-website` (ssg). `storybook` defines its own `build` task with `cache: false` and is untouched.

## Why

Cache was disabled, so every local and CI build redid the full Vite/vite-ssg build even when nothing changed. The likely original reason was undeclared env-var inputs (`VITE_*`, `HOST`) making Moon's hash incorrect — those are now declared explicitly.

## Inputs audit

If an input is **missed**, a stale cached build could ship. Please audit this list for completeness:

**Project files (relative to each project):**
- `.env*` — Vite mode env files (`.env`, `.env.production`, `.env.staging`); values are baked into bundles
- `index.html` — Vite entry
- `package.json` — build script + dependency declarations
- `public/**/*` — copied verbatim into `dist`
- `src/**/*` — application sources
- `tsconfig.json` — path/reference config
- `vite.config.ts` — build config (defines, plugins, ssg options)

**Workspace files:**
- `/libs/css/**/*`, `/libs/drawio/**/*`, `/libs/i18n/**/*`, `/libs/typescript/**/*`, `/libs/vite/**/*`, `/libs/vue/**/*` — all workspace libs that get bundled into frontend builds. Deliberately coarse (any frontend lib change invalidates all frontend build caches) because `project://^` only covers **direct** project dependencies; I verified empirically that a change in a transitive dep (`typescript-tera-api-sdk`, pulled in via `vue-tera`) did **not** invalidate `tera-app:build` with `project://^` alone. Not included: `libs/php` (backend), `libs/docker`/`libs/nginx` (consumed by separate uncached tasks), `libs/assets` (binary files, already globally excluded by `hasher.ignorePatterns`)
- `/yarn.lock` — dependency resolution; coarse but ensures transitive npm dep bumps rebuild
- `project://^` — all files of direct dependency projects; redundant with the lib globs today, kept so future `dependsOn` entries outside `/libs` stay covered

**Env vars:**
- `$VITE_*` (wildcard, supported by Moon and verified to hash any defined `VITE_`-prefixed var) — covers `VITE_UNHEAD_HOST`, `VITE_APP_ID`, `VITE_API_URL`, `VITE_ZITADEL_*`, `VITE_ESPACE_API_HOST`, `VITE_ESPACE_WEBSITE_HOST` and any future ones
- `$HOST` — expanded into `VITE_UNHEAD_HOST` by the ssg task env and by `.env` interpolation
- `$APP_ID` — interpolated by `projects/website/.env` and `projects/espace/*/.env`
- `$ESPACE_WEBSITE_HOST` (ssg) / `$ESPACE_API_HOST`, `$ZITADEL_CLIENT_ID`, `$ZITADEL_ISSUER`, `$ZITADEL_PROJECT_RESOURCE_ID` (pwa) — interpolated by espace `.env` files

**Hashed automatically by Moon (no declaration needed):** the task command/args including passthrough args (verified: `-- --mode=production` vs `-- --mode=staging` produce different hashes, so per-environment artifacts don't collide), the task definition files themselves, and `.moon/*` config.

## Verification

Ran locally with moon 2.3.2 / proto 0.57.4 (`proto install` + `yarn install`):

- `HOST=lychen.org moon run website:build` twice → second run is a cache hit (`cached, 75f2f4e7`), ~5s → ~0.1s
- Changing `HOST` → new hash (cache miss), reverting → original hash restored from cache
- Appending to `projects/website/index.html` → cache miss; revert → cache hit
- `moon run tera-app:build -- --mode=production` twice → cache hit; `--mode=staging` → different hash
- Setting `VITE_API_URL` → cache miss (wildcard env input works)
- Editing a **transitive** lib (`libs/typescript/tera/api-sdk`) → cache miss; revert → cache hit
- `rm -rf projects/website/dist` then cached run → `dist` fully rehydrated from cache
- `espace-website` and `espace-app` also build + cache-hit correctly

**Not verified:** `tera-website:build` and `robust-website:build` currently fail at `main` with pre-existing `MISSING_EXPORT` errors (e.g. `APP_STATE` is not exported by `libs/typescript/tera/core/constants/App.ts`, imported by `projects/tera/website/src/layouts/TheLayout.vue`) — unrelated to this change; failed tasks are correctly not cached. CI behavior (`moon ci :docker-buildx`) was not exercised.

## Risk & escape hatch

- **Stale-build risk:** if a build-affecting input is missing from the list above, a stale `dist` could be cached and shipped. The escape hatch is `moon <project>:build --updateCache` (or `-u`) to force a rebuild and overwrite the cache, or `moon clean` to drop local caches.
- **Pre-existing tradeoff inherited:** `hasher.ignorePatterns` in `.moon/workspace.yml` excludes binary assets (png/webp/ttf/...) from hashing workspace-wide, so image-only changes will not invalidate build caches (same behavior as lint/format tasks today).
- **Follow-up:** once local caching proves correct, enabling Moon remote caching would share these artifacts across CI runs and machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)