### PR TITLE
fix(ssg): serialize unhead v3 SEO tags into static HTML

### DIFF
--- a/libs/vite/ssg/package.json
+++ b/libs/vite/ssg/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@lychen/vue-i18n": "workspace:*",
     "@lychen/vue-router-configs": "workspace:*",
+    "@unhead/vue": "^3.1.3",
     "vue": "^3.5.35",
     "vue-router": "^5.1.0"
   },

--- a/libs/vite/ssg/ssgOptions.ts
+++ b/libs/vite/ssg/ssgOptions.ts
@@ -1,6 +1,7 @@
 import type { ViteSSGOptions } from 'vite-ssg';
 import generateSitemap from 'vite-ssg-sitemap';
 import type { RouteRecordRaw } from 'vue-router';
+import { transformHtmlTemplate } from '@unhead/vue/server';
 
 export const ssgOptions: ViteSSGOptions = {
   script: 'async',
@@ -13,6 +14,16 @@ export const ssgOptions: ViteSSGOptions = {
     });
   },
   dirStyle: 'nested',
+  // vite-ssg (≤28.x) still serializes heads through unhead v2 APIs, which
+  // silently no-op on the unhead v3 instances our apps create: pages build
+  // but title/canonical/og/JSON-LD never reach the HTML. Re-render the head
+  // ourselves with the v3 server transformer (it extracts the template's own
+  // tags, merges the app entries and re-applies everything, deduped).
+  // Drop this hook once vite-ssg ships unhead v3 support.
+  onPageRendered(_route, renderedHTML, appCtx) {
+    if (!appCtx.head) return renderedHTML;
+    return transformHtmlTemplate(appCtx.head, renderedHTML);
+  },
   onFinished() {
     // Fall back to the literal ${HOST} placeholder so a host-agnostic build can be
     // produced; the docker entrypoint substitutes it (envsubst) at container start.

--- a/libs/vue/unhead/composables/useExtendedHead.ts
+++ b/libs/vue/unhead/composables/useExtendedHead.ts
@@ -11,6 +11,11 @@ export function useExtendedHead(
 
   const host = import.meta.env.VITE_UNHEAD_HOST;
 
+  // Crawlers (Open Graph, Twitter) require absolute URLs for images.
+  function resolveAbsoluteUrl(url: string): string {
+    return url.startsWith('http') ? url : `https://${host}${url}`;
+  }
+
   function resolveLocalizedUrl(locale: string): string {
     if (route.name) {
       return `https://${host}${router.resolve({ name: route.name, params: { ...route.params, locale } }).path}`;
@@ -19,13 +24,15 @@ export function useExtendedHead(
     return `https://${host}${route.path.replace(localePattern, `/${locale}$2`)}`;
   }
 
+  const canonicalUrl =
+    options?.canonical ??
+    `https://${host}${router.resolve(route.name ? { name: route.name } : route).path}`;
+
   useHead({
     link: [
       {
         rel: 'canonical',
-        href:
-          options?.canonical ??
-          `https://${host}${router.resolve(route.name ? { name: route.name } : route).path}`,
+        href: canonicalUrl,
       },
       ...AVAILABLE_LOCALES.map(
         (locale) =>
@@ -50,7 +57,8 @@ export function useExtendedHead(
     description: t('meta.description'),
     ogDescription: t('meta.description'),
     ogTitle: t('meta.title'),
-    ogImage: options?.ogImage,
+    ogUrl: canonicalUrl,
+    ogImage: options?.ogImage ? resolveAbsoluteUrl(options.ogImage) : undefined,
     twitterCard: 'summary_large_image',
     twitterTitle: t('meta.title'),
     twitterDescription: t('meta.description'),

--- a/projects/espace/website/src/App.vue
+++ b/projects/espace/website/src/App.vue
@@ -7,7 +7,12 @@
 <script setup lang="ts">
 import { usePreferredColorScheme } from '@lychen/vue-color-scheme/composables/usePreferredColorScheme';
 import { TooltipProvider } from '@lychen/vue-components-core/tooltip';
-import { defineOrganization, defineWebPage, defineWebSite } from '@unhead/schema-org';
+import {
+  defineOrganization,
+  defineWebPage,
+  defineWebSite,
+  useSchemaOrg,
+} from '@unhead/schema-org/vue';
 import { useHead } from '@unhead/vue';
 import { useI18nExtended } from '@lychen/vue-i18n/composables/useI18nExtended';
 
@@ -21,17 +26,19 @@ useHead({
   },
   templateParams: {
     schemaOrg: {
-      host: import.meta.env.VITE_UNHEAD_HOST,
+      host: `https://${import.meta.env.VITE_UNHEAD_HOST}`,
     },
   },
 });
 
-defineOrganization({
-  name: title,
-  logo: '/logos/lychen/logo-lychen.svg',
-});
-defineWebSite({
-  name: title,
-});
-defineWebPage();
+useSchemaOrg([
+  defineOrganization({
+    name: title,
+    logo: '/logos/lychen/logo-lychen.svg',
+  }),
+  defineWebSite({
+    name: title,
+  }),
+  defineWebPage(),
+]);
 </script>

--- a/projects/robust/website/src/App.vue
+++ b/projects/robust/website/src/App.vue
@@ -4,7 +4,12 @@
 
 <script setup lang="ts">
 import { usePreferredColorScheme } from '@lychen/vue-color-scheme/composables/usePreferredColorScheme';
-import { defineOrganization, defineWebPage, defineWebSite } from '@unhead/schema-org';
+import {
+  defineOrganization,
+  defineWebPage,
+  defineWebSite,
+  useSchemaOrg,
+} from '@unhead/schema-org/vue';
 import { useHead } from '@unhead/vue';
 import { TRANSLATION_KEY, messages } from '@lychen/vue-robust/i18n';
 import { useI18nExtended } from '@lychen/vue-i18n/composables/useI18nExtended';
@@ -17,17 +22,19 @@ useHead({
   titleTemplate: `${t('name')} | %s`,
   templateParams: {
     schemaOrg: {
-      host: import.meta.env.VITE_UNHEAD_HOST,
+      host: `https://${import.meta.env.VITE_UNHEAD_HOST}`,
     },
   },
 });
 
-defineOrganization({
-  name: t('name'),
-  logo: '/logos/lychen/logo-lychen.svg',
-});
-defineWebSite({
-  name: t('name'),
-});
-defineWebPage();
+useSchemaOrg([
+  defineOrganization({
+    name: t('name'),
+    logo: '/logos/lychen/logo-lychen.svg',
+  }),
+  defineWebSite({
+    name: t('name'),
+  }),
+  defineWebPage(),
+]);
 </script>

--- a/projects/tera/website/src/App.vue
+++ b/projects/tera/website/src/App.vue
@@ -5,7 +5,12 @@
 <script setup lang="ts">
 import { useI18nExtended } from '@lychen/vue-i18n/composables/useI18nExtended';
 import { usePreferredColorScheme } from '@lychen/vue-color-scheme/composables/usePreferredColorScheme';
-import { defineOrganization, defineWebPage, defineWebSite } from '@unhead/schema-org';
+import {
+  defineOrganization,
+  defineWebPage,
+  defineWebSite,
+  useSchemaOrg,
+} from '@unhead/schema-org/vue';
 import { useHead } from '@unhead/vue';
 import { TRANSLATION_KEY, messages } from '@lychen/vue-tera/i18n';
 
@@ -17,17 +22,19 @@ useHead({
   titleTemplate: `${t('name')} | %s`,
   templateParams: {
     schemaOrg: {
-      host: import.meta.env.VITE_UNHEAD_HOST,
+      host: `https://${import.meta.env.VITE_UNHEAD_HOST}`,
     },
   },
 });
 
-defineOrganization({
-  name: t('name'),
-  logo: '/logos/lychen/logo-lychen.svg',
-});
-defineWebSite({
-  name: t('name'),
-});
-defineWebPage();
+useSchemaOrg([
+  defineOrganization({
+    name: t('name'),
+    logo: '/logos/lychen/logo-lychen.svg',
+  }),
+  defineWebSite({
+    name: t('name'),
+  }),
+  defineWebPage(),
+]);
 </script>

--- a/projects/website/src/App.vue
+++ b/projects/website/src/App.vue
@@ -7,7 +7,12 @@
 <script setup lang="ts">
 import { usePreferredColorScheme } from '@lychen/vue-color-scheme/composables/usePreferredColorScheme';
 import { useI18nExtended } from '@lychen/vue-i18n/composables/useI18nExtended';
-import { defineOrganization, defineWebPage, defineWebSite } from '@unhead/schema-org';
+import {
+  defineOrganization,
+  defineWebPage,
+  defineWebSite,
+  useSchemaOrg,
+} from '@unhead/schema-org/vue';
 import { useHead } from '@unhead/vue';
 import { defineAsyncComponent } from 'vue';
 
@@ -26,17 +31,19 @@ useHead({
   },
   templateParams: {
     schemaOrg: {
-      host: import.meta.env.VITE_UNHEAD_HOST,
+      host: `https://${import.meta.env.VITE_UNHEAD_HOST}`,
     },
   },
 });
 
-defineOrganization({
-  name: 'lychen',
-  logo: '/logos/lychen/logo-lychen.svg',
-});
-defineWebSite({
-  name: 'lychen',
-});
-defineWebPage();
+useSchemaOrg([
+  defineOrganization({
+    name: 'lychen',
+    logo: '/logos/lychen/logo-lychen.svg',
+  }),
+  defineWebSite({
+    name: 'lychen',
+  }),
+  defineWebPage(),
+]);
 </script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,24 @@
   "extends": "./tsconfig.options.json",
   "references": [
     {
+      "path": "./libs/vite/ssg"
+    },
+    {
+      "path": "./libs/vue/unhead/composables"
+    },
+    {
+      "path": "./projects/espace/website"
+    },
+    {
+      "path": "./projects/robust/website"
+    },
+    {
+      "path": "./projects/tera/website"
+    },
+    {
+      "path": "./projects/website"
+    },
+    {
       "path": "libs/i18n/tera"
     },
     {
@@ -48,9 +66,6 @@
     },
     {
       "path": "libs/typescript/zitadel"
-    },
-    {
-      "path": "libs/vite/ssg"
     },
     {
       "path": "libs/vue/applications"
@@ -131,19 +146,10 @@
       "path": "libs/vue/tiptap"
     },
     {
-      "path": "libs/vue/unhead/composables"
-    },
-    {
       "path": "libs/vue/vara"
     },
     {
       "path": "projects/espace/app"
-    },
-    {
-      "path": "projects/espace/website"
-    },
-    {
-      "path": "projects/robust/website"
     },
     {
       "path": "projects/storybook"
@@ -153,12 +159,6 @@
     },
     {
       "path": "projects/tera/tests-e2e"
-    },
-    {
-      "path": "projects/tera/website"
-    },
-    {
-      "path": "projects/website"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2606,6 +2606,7 @@ __metadata:
   dependencies:
     "@lychen/vue-i18n": "workspace:*"
     "@lychen/vue-router-configs": "workspace:*"
+    "@unhead/vue": "npm:^3.1.3"
     "@vitejs/plugin-vue": "npm:^6.0.7"
     vite: "npm:^8.0.16"
     vite-ssg: "npm:^28.3.0"
@@ -5204,14 +5205,14 @@ __metadata:
   linkType: hard
 
 "@unhead/vue@npm:^2.1.2":
-  version: 2.1.10
-  resolution: "@unhead/vue@npm:2.1.10"
+  version: 2.1.15
+  resolution: "@unhead/vue@npm:2.1.15"
   dependencies:
     hookable: "npm:^6.0.1"
-    unhead: "npm:2.1.10"
+    unhead: "npm:2.1.15"
   peerDependencies:
     vue: ">=3.5.18"
-  checksum: 10c0/00174ebc15e81ce923ecab0e017daad6928f6789ee3676d04a151d3f6f45c09496b8c58eeb20e02aa0c609076beabc6ba0422b633ba43655a5c44ff6837f85f1
+  checksum: 10c0/f0923ec4a01b4449b458c8554c7498e59c137b642b225fca28132948a797db5dc4bc807d64600e5ec17137d73723d3750bafa73935addaf6898bc4f11f89c15b
   languageName: node
   linkType: hard
 
@@ -13011,12 +13012,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unhead@npm:2.1.10":
-  version: 2.1.10
-  resolution: "unhead@npm:2.1.10"
+"unhead@npm:2.1.15":
+  version: 2.1.15
+  resolution: "unhead@npm:2.1.15"
   dependencies:
     hookable: "npm:^6.0.1"
-  checksum: 10c0/c94ebad9ef6fae99fb1c34fe5454960bdc0dfbffcd7998d481a095d3cb1b2579430a1016f85528e74a63a85c0102ea2768331ac79e906c87f2bbc9cb25625ea4
+  checksum: 10c0/ab266e9cda44d0b528ae3b62ce9136cb4f81bd2aa1e2d66431cefe6b41151a811971951e05b4d81e6adea105b65901d9091dffa29d646f1be6246691606b2407
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

The SSG websites shipped **without any SEO tags** in the generated static HTML: no `<title>`, no `canonical`, no `hreflang`, no `description`/Open Graph/Twitter meta, no schema.org JSON-LD. Pages built successfully and the body rendered fine, so nothing flagged the regression.

## Root causes

**1. vite-ssg serializes heads with unhead v2 APIs; our apps create unhead v3 instances.**
`vite-ssg` — including the latest 28.3.0 — still depends on `@unhead/vue@^2` and renders heads node-side with the v2-era `renderDOMHead`. The SSR bundle resolves `@unhead/vue/server` to the workspace's v3 copy, so the head instance handed back to vite-ssg is a v3 server head. The renderer early-returns on a head that is neither `dirty` nor has pending entries — which a v3 server head never is. Result: a **silent no-op**, head entries are collected but never written to the output document.

**2. schema.org nodes were never registered.**
`defineOrganization()`/`defineWebSite()`/`defineWebPage()` are pure factories returning node objects; calling them standalone (as the `App.vue` files did) registers nothing. They must be wrapped in `useSchemaOrg([...])`.

## Changes

- **Stay on unhead v3** and bypass vite-ssg's broken serialization: the shared `ssgOptions` (in `@lychen/vite-ssg`) gains an `onPageRendered` hook that re-renders the head with v3's documented server API, [`transformHtmlTemplate()`](https://unhead.unjs.io/docs/vue/head/guides/get-started/migration) — it extracts the template's own tags, merges the app entries and re-applies everything, deduped. The hook can be dropped once vite-ssg ships unhead v3 support.
- Wrap the schema.org `define*` calls in `useSchemaOrg([...])` (imported from `@unhead/schema-org/vue`) in all four `App.vue`.
- `templateParams.schemaOrg.host` now includes the `https://` scheme — the JSON-LD graph previously produced protocol-less `@id` URLs.
- `useExtendedHead`: resolve `og:image` to an absolute URL (required by Open Graph crawlers) and emit `og:url` aligned with the canonical.
- `@lychen/vite-ssg` declares `@unhead/vue` as a dependency for the new import.

## Verification

Built `website` and `espace-website`. Every page now contains, per locale (`fr-FR`/`en-US`):
- localized `<title>` with the titleTemplate applied, correct `<html lang>`
- `canonical` + `hreflang` alternates (incl. `x-default`) specific to each page
- `description`, `og:*` (title/description/url/absolute image), `twitter:*`
- a valid schema.org JSON-LD graph (Organization/WebSite/WebPage) with `https://`-prefixed `@id`s
- no duplicated tags (charset/viewport/favicon from the template each appear exactly once)

The `${HOST}` placeholder remains in host-agnostic builds and is substituted by envsubst at container start, as before.

## Notes for reviewers

- vite-ssg keeps its own nested unhead v2 copy for internal use; its `renderDOMHead` call remains a harmless no-op on our v3 heads. If vite-ssg ever resolves a v2 head instead, `transformHtmlTemplate` would fail loudly (no silent regression).
- `tera-website` and `robust-website` do **not** build on `main` for unrelated pre-existing reasons (rolldown `MISSING_EXPORT`: `messages`/`TRANSLATION_KEY` from `@lychen/vue-applications/i18n`, `APP_STATE` from `@lychen/typescript-robust/constants/App`). Verified via `git stash` that the failures pre-date this branch. The fixes here apply to them and will take effect once those imports are repaired (tracked separately).
- A cheap smoke test for future bumps: `grep -c '<title>' projects/website/dist/fr-FR/index.html` after a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)