### PR TITLE
feat(website): redesign mission & label pages, fix home SDG icon

### DIFF
--- a/projects/website/src/views/home/PageHomeODD.vue
+++ b/projects/website/src/views/home/PageHomeODD.vue
@@ -20,7 +20,7 @@
         <div class="relative">
           <img
             v-if="selectedGoal"
-            :src="`sustainable-development-goals/icons/${selectedGoal.icon}`"
+            :src="`/sustainable-development-goals/icons/${selectedGoal.icon}`"
             class="odd-icon absolute z-10 h-14 rounded-2xl md:h-24"
             :alt="`Icône de l'objectif de développement durable n° ${selectedGoal.index}`"
           />

--- a/projects/website/src/views/label/View.vue
+++ b/projects/website/src/views/label/View.vue
@@ -1,123 +1,355 @@
 <template>
-  <Container class="flex flex-col gap-16 pt-20">
-    <!-- Hero Section -->
-    <div class="mx-auto flex max-w-4xl flex-col items-center gap-6 text-center">
-      <Title
-        variant="h1"
-        class="text-balance"
-        >{{ t('hero.title') }}</Title
+  <!-- ============================================================= HERO -->
+  <section
+    ref="heroRoot"
+    class="label-hero relative overflow-hidden"
+  >
+    <!-- Layered decorative background: gradient wash + blobs -->
+    <div
+      aria-hidden="true"
+      class="label-hero-grade absolute inset-0 z-0"
+    />
+    <div
+      aria-hidden="true"
+      class="label-blob label-blob-transition absolute z-0"
+    />
+    <div
+      aria-hidden="true"
+      class="label-blob label-blob-preservation absolute z-0"
+    />
+    <div
+      aria-hidden="true"
+      class="label-blob label-blob-regeneration absolute z-0"
+    />
+
+    <!-- Decorative ridge silhouette at the bottom of the hero -->
+    <svg
+      aria-hidden="true"
+      class="label-hero-ridge absolute inset-x-0 -bottom-px z-[1] h-[22svh] w-full dark:brightness-[0.6]"
+      viewBox="0 0 1440 320"
+      preserveAspectRatio="none"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <linearGradient
+          id="label-hero-ridge-gradient"
+          x1="0"
+          y1="0"
+          x2="0"
+          y2="1"
+        >
+          <stop
+            offset="0"
+            stop-color="oklch(0.62 0.05 150)"
+          />
+          <stop
+            offset="1"
+            stop-color="oklch(0.45 0.055 145)"
+          />
+        </linearGradient>
+      </defs>
+      <path
+        d="M0 190 C 140 160, 260 118, 420 130 C 580 142, 660 194, 820 198 C 980 202, 1100 148, 1240 152 C 1320 154, 1400 168, 1440 174 L 1440 320 L 0 320 Z"
+        fill="url(#label-hero-ridge-gradient)"
+      />
+      <path
+        d="M0 190 C 140 160, 260 118, 420 130 C 580 142, 660 194, 820 198 C 980 202, 1100 148, 1240 152 C 1320 154, 1400 168, 1440 174"
+        stroke="oklch(0.95 0.03 140 / 0.2)"
+        stroke-width="1.5"
+        vector-effect="non-scaling-stroke"
+      />
+    </svg>
+
+    <Container class="relative z-10">
+      <div
+        ref="heroCopy"
+        class="label-reveal-group mx-auto flex max-w-4xl flex-col items-center gap-6 pt-28 pb-32 text-center md:pt-36"
+        :class="{ 'label-revealed': heroRevealed }"
       >
-      <Paragraph class="text-lg opacity-80">{{ t('hero.description') }}</Paragraph>
-    </div>
-  </Container>
-
-  <Container>
-    <!-- The Scale Section -->
-    <div class="flex flex-col gap-8">
-      <div class="grid grid-cols-1 gap-8 md:grid-cols-3">
-        <!-- Transition (1-3) -->
-        <div
-          class="bg-surface-container/50 border-surface-outline flex flex-col gap-4 rounded-3xl border p-6"
+        <span
+          class="border-on-surface/15 bg-surface-container-low/70 inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-xs font-semibold tracking-widest uppercase backdrop-blur-md"
         >
-          <div class="mb-4 flex flex-col items-center gap-2">
-            <Title
-              variant="h3"
-              class="text-yellow-600 dark:text-yellow-400"
-              >{{ t('tranches.transition.title') }}</Title
-            >
-            <span class="text-sm opacity-60">{{ t('tranches.transition.subtitle') }}</span>
-          </div>
-          <div class="flex flex-wrap justify-center gap-4">
-            <RobustLabel :level="1" />
-            <RobustLabel :level="2" />
-            <RobustLabel :level="3" />
-          </div>
-          <Paragraph class="mt-4 text-center text-sm">{{
-            t('tranches.transition.description')
-          }}</Paragraph>
-        </div>
+          <span class="bg-primary size-1.5 animate-pulse rounded-full" />
+          {{ t('hero.badge') }}
+        </span>
 
-        <!-- Preservation (4-7) -->
-        <div
-          class="bg-surface-container/50 border-surface-outline flex flex-col gap-4 rounded-3xl border p-6"
+        <Title
+          variant="h1"
+          class="font-lexend max-w-4xl text-[clamp(2.5rem,6vw,4.75rem)] leading-[1.06] font-extrabold tracking-tight text-balance"
+          >{{ t('hero.title.prepend')
+          }}<span
+            class="from-primary bg-gradient-to-r via-[oklch(0.65_0.1_150)] to-[oklch(0.6_0.12_180)] bg-clip-text text-transparent dark:from-[oklch(0.88_0.13_131)] dark:via-[oklch(0.85_0.11_150)] dark:to-[oklch(0.82_0.1_180)]"
+            >{{ t('hero.title.key_word') }}</span
+          >{{ t('hero.title.append') }}</Title
         >
-          <div class="mb-4 flex flex-col items-center gap-2">
-            <Title
-              variant="h3"
-              class="text-emerald-600 dark:text-emerald-400"
-              >{{ t('tranches.preservation.title') }}</Title
-            >
-            <span class="text-sm opacity-60">{{ t('tranches.preservation.subtitle') }}</span>
-          </div>
-          <div class="flex flex-wrap justify-center gap-4">
-            <RobustLabel :level="4" />
-            <RobustLabel :level="5" />
-            <RobustLabel :level="6" />
-            <RobustLabel :level="7" />
-          </div>
-          <Paragraph class="mt-4 text-center text-sm">{{
-            t('tranches.preservation.description')
-          }}</Paragraph>
-        </div>
 
-        <!-- Regeneration (8-10) -->
-        <div
-          class="bg-surface-container/50 border-surface-outline flex flex-col gap-4 rounded-3xl border shadow-lg shadow-amber-500/10"
+        <Paragraph
+          variant="website-highlight"
+          class="max-w-2xl opacity-80"
+          >{{ t('hero.description') }}</Paragraph
         >
-          <div class="mb-4 flex flex-col items-center gap-2">
-            <Title
-              variant="h3"
-              class="text-amber-600 dark:text-amber-400"
-              >{{ t('tranches.regeneration.title') }}</Title
-            >
-            <span class="text-sm opacity-60">{{ t('tranches.regeneration.subtitle') }}</span>
-          </div>
-          <div class="flex flex-wrap justify-center gap-4">
-            <RobustLabel :level="8" />
-            <RobustLabel :level="9" />
-            <RobustLabel :level="10" />
-          </div>
-          <Paragraph class="mt-4 text-center text-sm">{{
-            t('tranches.regeneration.description')
-          }}</Paragraph>
-        </div>
-      </div>
-    </div>
-  </Container>
 
-  <Container>
-    <!-- Gamification / Context -->
-    <div class="grid items-center gap-12 md:grid-cols-2">
-      <div class="flex flex-col gap-6">
-        <Title variant="h2">{{ t('gamification.title') }}</Title>
-        <Paragraph>{{ t('gamification.description') }}</Paragraph>
-        <ul class="flex flex-col gap-4">
-          <li
-            v-for="(_, i) in 4"
-            :key="i"
-            class="bg-surface-container flex items-center gap-4 rounded-xl p-3"
+        <!-- Scale hint chip -->
+        <span
+          class="border-on-surface/10 bg-surface-container-low/60 inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold backdrop-blur-md"
+        >
+          <IconSprout class="text-primary size-4" />
+          {{ t('hero.scale_hint') }}
+        </span>
+
+        <!-- Stats row -->
+        <dl class="mt-4 grid w-full max-w-2xl grid-cols-3 gap-4">
+          <div
+            v-for="stat in HERO_STATS"
+            :key="stat.key"
+            class="border-on-surface/10 bg-surface-container-low/50 flex flex-col items-center gap-1 rounded-2xl border px-3 py-5 backdrop-blur-sm"
           >
+            <dt
+              class="from-primary bg-gradient-to-r to-[oklch(0.6_0.12_180)] bg-clip-text font-lexend text-3xl font-black text-transparent md:text-4xl"
+            >
+              {{ t(`hero.stats.${stat.key}.value`) }}
+            </dt>
+            <dd class="text-xs font-medium opacity-60">
+              {{ t(`hero.stats.${stat.key}.label`) }}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </Container>
+  </section>
+
+  <!-- ====================================================== SCALE SECTION -->
+  <section
+    ref="scaleRoot"
+    class="relative overflow-hidden py-20 md:py-28"
+  >
+    <div
+      aria-hidden="true"
+      class="label-blob label-blob-soft absolute top-10 -left-24 z-0"
+    />
+
+    <Container class="relative z-10 flex flex-col gap-14">
+      <!-- Section heading -->
+      <div
+        ref="scaleHeading"
+        class="label-reveal-group mx-auto flex max-w-3xl flex-col items-center gap-5 text-center"
+        :class="{ 'label-revealed': scaleRevealed }"
+      >
+        <span class="text-primary text-xs font-bold tracking-[0.2em] uppercase">{{
+          t('scale.kicker')
+        }}</span>
+        <Title
+          variant="h2"
+          class="font-lexend text-4xl font-extrabold tracking-tight md:text-5xl"
+          >{{ t('scale.title.prepend')
+          }}<span
+            class="from-primary bg-gradient-to-r via-[oklch(0.65_0.1_150)] to-[oklch(0.55_0.12_180)] bg-clip-text text-transparent"
+            >{{ t('scale.title.key_word') }}</span
+          >{{ t('scale.title.append') }}</Title
+        >
+        <Paragraph
+          variant="website-highlight"
+          class="opacity-80"
+          >{{ t('scale.description') }}</Paragraph
+        >
+      </div>
+
+      <!-- Three tranches -->
+      <div class="grid grid-cols-1 gap-8 lg:grid-cols-3">
+        <article
+          v-for="(tranche, index) in TRANCHES"
+          :key="tranche.key"
+          ref="trancheCards"
+          class="label-tranche group border-on-surface/10 relative flex flex-col gap-5 overflow-hidden rounded-3xl border p-6"
+          :class="[tranche.surfaceClass, { 'label-tranche-revealed': scaleRevealed }]"
+          :style="{ '--reveal-delay': `${0.1 + index * 0.14}s` }"
+        >
+          <!--
+            IMAGE PLACEHOLDER: tranche illustration
+            (transition = field starting conversion, preservation = balanced
+            plots with groves/ponds, regeneration = thriving agroecological
+            farm seen from above). Midjourney prompts in ClickUp.
+          -->
+          <div
+            aria-hidden="true"
+            class="label-placeholder relative flex h-40 items-end justify-between overflow-hidden rounded-2xl p-4"
+            :class="tranche.placeholderClass"
+          >
+            <span class="label-placeholder-grain absolute inset-0" />
+            <span
+              class="bg-surface/70 text-on-surface relative z-10 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-bold backdrop-blur-md"
+            >
+              <component
+                :is="tranche.icon"
+                class="size-3.5"
+                :class="tranche.accentClass"
+              />
+              {{ t(`tranches.${tranche.key}.subtitle`) }}
+            </span>
+            <span class="relative z-10 font-lexend text-5xl font-black text-white/35">
+              {{ tranche.levels }}
+            </span>
+          </div>
+
+          <div class="flex flex-col items-center gap-1.5 text-center">
+            <Title
+              variant="h3"
+              :class="tranche.accentClass"
+              >{{ t(`tranches.${tranche.key}.title`) }}</Title
+            >
+            <span class="text-sm opacity-60">{{ t(`tranches.${tranche.key}.subtitle`) }}</span>
+          </div>
+
+          <div class="flex flex-wrap justify-center gap-4">
             <RobustLabel
-              :level="[6, 4, 5, 8][i] ?? 1"
-              size="sm"
-              class="scale-75"
+              v-for="level in tranche.badges"
+              :key="level"
+              :level="level"
             />
-            <div class="flex flex-col">
-              <span class="font-bold">{{ t(`gamification.examples.${i}.role`) }}</span>
-              <span class="text-sm opacity-60">{{ t(`gamification.examples.${i}.points`) }}</span>
-            </div>
-          </li>
-        </ul>
+          </div>
+
+          <Paragraph class="text-center text-sm opacity-80">{{
+            t(`tranches.${tranche.key}.description`)
+          }}</Paragraph>
+        </article>
       </div>
-      <div class="flex flex-col gap-6">
-        <Title variant="h2">{{ t('vision.title') }}</Title>
-        <Paragraph>{{ t('vision.description') }}</Paragraph>
+    </Container>
+  </section>
+
+  <!-- =============================================== GAMIFICATION SECTION -->
+  <section
+    ref="gamificationRoot"
+    class="relative overflow-hidden py-20 md:py-28"
+  >
+    <div
+      aria-hidden="true"
+      class="label-blob label-blob-soft absolute -right-24 bottom-0 z-0"
+    />
+
+    <Container class="relative z-10">
+      <div class="grid items-center gap-12 lg:grid-cols-2">
+        <!-- Text + scores -->
+        <div
+          ref="gamificationCopy"
+          class="label-reveal-group flex flex-col gap-6"
+          :class="{ 'label-revealed': gamificationRevealed }"
+        >
+          <span class="text-primary text-xs font-bold tracking-[0.2em] uppercase">{{
+            t('gamification.kicker')
+          }}</span>
+          <Title
+            variant="h2"
+            class="font-lexend text-3xl font-extrabold tracking-tight md:text-4xl"
+            >{{ t('gamification.title') }}</Title
+          >
+          <Paragraph class="opacity-80">{{ t('gamification.description') }}</Paragraph>
+
+          <span class="text-sm font-bold opacity-70">{{ t('gamification.examples_title') }}</span>
+          <ul class="flex flex-col gap-3">
+            <li
+              v-for="(example, i) in GAMIFICATION_EXAMPLES"
+              :key="i"
+              class="border-on-surface/10 bg-surface-container-low/60 flex items-center gap-4 rounded-2xl border p-3 backdrop-blur-sm transition-transform duration-300 hover:translate-x-1"
+            >
+              <RobustLabel
+                :level="example.level"
+                size="sm"
+                class="scale-75"
+              />
+              <div class="flex flex-col">
+                <span class="font-bold">{{ t(`gamification.examples.${i}.role`) }}</span>
+                <span class="text-sm opacity-60">{{ t(`gamification.examples.${i}.points`) }}</span>
+              </div>
+            </li>
+          </ul>
+        </div>
+
+        <!--
+          IMAGE PLACEHOLDER: local community celebrating their territory's
+          progress around a scoreboard. Midjourney prompt in ClickUp.
+        -->
+        <div
+          ref="gamificationFigure"
+          class="label-reveal-figure order-first lg:order-last"
+          :class="{ 'label-figure-revealed': gamificationRevealed }"
+        >
+          <div
+            aria-hidden="true"
+            class="label-placeholder label-placeholder-community ring-on-surface/10 relative flex aspect-[4/3] items-end overflow-hidden rounded-3xl shadow-xl ring-1"
+          >
+            <span class="label-placeholder-grain absolute inset-0" />
+            <span
+              class="bg-surface/70 text-on-surface relative z-10 m-4 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-bold backdrop-blur-md"
+            >
+              <IconUsers class="text-primary size-3.5" />
+              {{ t('gamification.image_alt') }}
+            </span>
+          </div>
+        </div>
       </div>
-    </div>
-  </Container>
+    </Container>
+  </section>
+
+  <!-- ===================================================== VISION SECTION -->
+  <section
+    ref="visionRoot"
+    class="relative overflow-hidden py-20 md:py-28"
+  >
+    <Container class="relative z-10">
+      <div class="grid items-center gap-12 lg:grid-cols-2">
+        <!--
+          IMAGE PLACEHOLDER: a Robust label proudly displayed on a local
+          product, in soft natural light. Midjourney prompt in ClickUp.
+        -->
+        <div
+          ref="visionFigure"
+          class="label-reveal-figure"
+          :class="{ 'label-figure-revealed': visionRevealed }"
+        >
+          <div
+            aria-hidden="true"
+            class="label-placeholder label-placeholder-product ring-on-surface/10 relative flex aspect-[4/3] items-end overflow-hidden rounded-3xl shadow-xl ring-1"
+          >
+            <span class="label-placeholder-grain absolute inset-0" />
+            <RobustLabel
+              :level="9"
+              size="lg"
+              class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+            />
+            <span
+              class="bg-surface/70 text-on-surface relative z-10 m-4 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-bold backdrop-blur-md"
+            >
+              <IconBadgeCheck class="text-primary size-3.5" />
+              {{ t('vision.image_alt') }}
+            </span>
+          </div>
+        </div>
+
+        <div
+          ref="visionCopy"
+          class="label-reveal-group flex flex-col gap-6"
+          :class="{ 'label-revealed': visionRevealed }"
+        >
+          <span class="text-primary text-xs font-bold tracking-[0.2em] uppercase">{{
+            t('vision.kicker')
+          }}</span>
+          <Title
+            variant="h2"
+            class="font-lexend text-3xl font-extrabold tracking-tight md:text-4xl"
+            >{{ t('vision.title') }}</Title
+          >
+          <Paragraph class="opacity-80">{{ t('vision.description') }}</Paragraph>
+        </div>
+      </div>
+    </Container>
+  </section>
 </template>
 
 <script lang="ts" setup>
+import { ref } from 'vue';
+import { useIntersectionObserver } from '@vueuse/core';
+
 import { usePrefixedI18n } from '@lychen/vue-i18n/composables/useI18nExtended';
 import { CONFIG } from './i18n';
 import Container from '@lychen/vue-components-website/container/Container.vue';
@@ -125,7 +357,264 @@ import Title from '@lychen/vue-components-website/title/Title.vue';
 import Paragraph from '@lychen/vue-components-website/paragraph/Paragraph.vue';
 import RobustLabel from './RobustLabel.vue';
 import { useExtendedHead } from '@lychen/vue-unhead-composables/useExtendedHead';
+import IconSprout from '@lychen/vue-icons/IconSprout.vue';
+import IconShieldCheck from '@lychen/vue-icons/IconShieldCheck.vue';
+import IconEarth from '@lychen/vue-icons/IconEarth.vue';
+import IconUsers from '@lychen/vue-icons/IconUsers.vue';
+import IconBadgeCheck from '@lychen/vue-icons/IconBadgeCheck.vue';
 
 const { t } = usePrefixedI18n(CONFIG);
 useExtendedHead(t);
+
+const HERO_STATS = [{ key: 'levels' }, { key: 'tranches' }, { key: 'scope' }] as const;
+
+const TRANCHES = [
+  {
+    key: 'transition',
+    levels: '1–3',
+    badges: [1, 2, 3],
+    icon: IconSprout,
+    accentClass: 'text-yellow-600 dark:text-yellow-400',
+    surfaceClass: 'bg-yellow-50/40 dark:bg-yellow-950/15',
+    placeholderClass: 'label-placeholder-transition',
+  },
+  {
+    key: 'preservation',
+    levels: '4–7',
+    badges: [4, 5, 6, 7],
+    icon: IconShieldCheck,
+    accentClass: 'text-emerald-600 dark:text-emerald-400',
+    surfaceClass: 'bg-emerald-50/40 dark:bg-emerald-950/15',
+    placeholderClass: 'label-placeholder-preservation',
+  },
+  {
+    key: 'regeneration',
+    levels: '8–10',
+    badges: [8, 9, 10],
+    icon: IconEarth,
+    accentClass: 'text-amber-600 dark:text-amber-400',
+    surfaceClass:
+      'bg-amber-50/50 shadow-lg shadow-amber-500/10 dark:bg-amber-950/15 dark:shadow-amber-500/5',
+    placeholderClass: 'label-placeholder-regeneration',
+  },
+] as const;
+
+const GAMIFICATION_EXAMPLES = [
+  { level: 6 },
+  { level: 4 },
+  { level: 5 },
+  { level: 8 },
+] as const;
+
+function useReveal(threshold = 0.25) {
+  const target = ref<HTMLElement | null>(null);
+  const revealed = ref(false);
+  useIntersectionObserver(
+    target,
+    (entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        revealed.value = true;
+      }
+    },
+    { threshold },
+  );
+  return { target, revealed };
+}
+
+const { target: heroCopy, revealed: heroRevealed } = useReveal(0.1);
+const { target: scaleHeading, revealed: scaleRevealed } = useReveal(0.2);
+const { target: gamificationCopy, revealed: gamificationRevealed } = useReveal(0.2);
+const { target: visionCopy, revealed: visionRevealed } = useReveal(0.2);
+
+// Refs used only as scroll/animation anchors (kept for clarity & future parallax).
+const heroRoot = ref<HTMLElement | null>(null);
+const scaleRoot = ref<HTMLElement | null>(null);
+const trancheCards = ref<HTMLElement[] | null>(null);
+const gamificationRoot = ref<HTMLElement | null>(null);
+const gamificationFigure = ref<HTMLElement | null>(null);
+const visionRoot = ref<HTMLElement | null>(null);
+const visionFigure = ref<HTMLElement | null>(null);
 </script>
+
+<style scoped>
+/* ---------------------------------------------------------------- HERO */
+.label-hero-grade {
+  background:
+    radial-gradient(80% 60% at 50% 0%, oklch(0.7 0.08 150 / 0.18), transparent 70%),
+    linear-gradient(180deg, oklch(0.95 0.02 150 / 0.5) 0%, transparent 60%);
+}
+
+:global(.dark) .label-hero-grade {
+  background:
+    radial-gradient(80% 60% at 50% 0%, oklch(0.6 0.1 150 / 0.18), transparent 70%),
+    linear-gradient(180deg, oklch(0.3 0.06 150 / 0.35) 0%, transparent 60%);
+}
+
+/* ----------------------------------------------------- DECORATIVE BLOBS */
+.label-blob {
+  width: clamp(280px, 38vw, 560px);
+  height: clamp(280px, 38vw, 560px);
+  border-radius: 9999px;
+  filter: blur(90px);
+  pointer-events: none;
+}
+
+.label-blob-transition {
+  top: -8%;
+  left: -6%;
+  background: oklch(0.85 0.13 95);
+  opacity: 0.14;
+}
+
+.label-blob-preservation {
+  top: 10%;
+  right: -8%;
+  background: oklch(0.7 0.13 150);
+  opacity: 0.12;
+}
+
+.label-blob-regeneration {
+  bottom: -10%;
+  left: 30%;
+  background: oklch(0.78 0.13 75);
+  opacity: 0.1;
+}
+
+.label-blob-soft {
+  background: var(--color-primary);
+  opacity: 0.08;
+}
+
+/* ------------------------------------------------------ IMAGE PLACEHOLDERS */
+.label-placeholder {
+  background-position: center;
+  background-size: cover;
+}
+
+/* Subtle grain/texture overlay shared by every placeholder block */
+.label-placeholder-grain {
+  background-image: radial-gradient(rgb(255 255 255 / 0.16) 1px, transparent 1.4px);
+  background-size: 14px 14px;
+  mix-blend-mode: overlay;
+  opacity: 0.5;
+}
+
+.label-placeholder-transition {
+  background-image: linear-gradient(
+    135deg,
+    oklch(0.82 0.13 95) 0%,
+    oklch(0.72 0.12 120) 60%,
+    oklch(0.6 0.11 135) 100%
+  );
+}
+
+.label-placeholder-preservation {
+  background-image: linear-gradient(
+    135deg,
+    oklch(0.74 0.12 150) 0%,
+    oklch(0.6 0.12 160) 55%,
+    oklch(0.46 0.1 165) 100%
+  );
+}
+
+.label-placeholder-regeneration {
+  background-image: linear-gradient(
+    135deg,
+    oklch(0.8 0.13 80) 0%,
+    oklch(0.66 0.13 110) 55%,
+    oklch(0.5 0.12 150) 100%
+  );
+}
+
+.label-placeholder-community {
+  background-image: linear-gradient(
+    140deg,
+    oklch(0.74 0.11 150) 0%,
+    oklch(0.58 0.12 165) 50%,
+    oklch(0.44 0.1 175) 100%
+  );
+}
+
+.label-placeholder-product {
+  background-image: linear-gradient(
+    140deg,
+    oklch(0.85 0.1 95) 0%,
+    oklch(0.7 0.12 130) 55%,
+    oklch(0.52 0.11 155) 100%
+  );
+}
+
+/* --------------------------------------------------- SCROLL REVEALS */
+/* Grouped copy: children fade/slide up with a small stagger. */
+.label-reveal-group > * {
+  opacity: 0;
+  translate: 0 26px;
+  transition:
+    opacity 0.7s ease,
+    translate 0.7s ease;
+}
+
+.label-reveal-group > *:nth-child(2) {
+  transition-delay: 0.1s;
+}
+
+.label-reveal-group > *:nth-child(3) {
+  transition-delay: 0.2s;
+}
+
+.label-reveal-group > *:nth-child(4) {
+  transition-delay: 0.3s;
+}
+
+.label-reveal-group > *:nth-child(5) {
+  transition-delay: 0.4s;
+}
+
+.label-reveal-group > *:nth-child(6) {
+  transition-delay: 0.5s;
+}
+
+.label-revealed > * {
+  opacity: 1;
+  translate: 0 0;
+}
+
+/* Tranche cards: staggered reveal driven by --reveal-delay. */
+.label-tranche {
+  opacity: 0;
+  translate: 0 32px;
+  transition:
+    opacity 0.7s ease,
+    translate 0.7s ease;
+  transition-delay: var(--reveal-delay, 0s);
+}
+
+.label-tranche-revealed {
+  opacity: 1;
+  translate: 0 0;
+}
+
+/* Figures slide in from the side. */
+.label-reveal-figure {
+  opacity: 0;
+  translate: 28px 0;
+  transition:
+    opacity 0.8s ease,
+    translate 0.8s ease;
+}
+
+.label-figure-revealed {
+  opacity: 1;
+  translate: 0 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .label-reveal-group > *,
+  .label-tranche,
+  .label-reveal-figure {
+    opacity: 1;
+    translate: 0 0;
+    transition: none;
+  }
+}
+</style>

--- a/projects/website/src/views/label/View.vue
+++ b/projects/website/src/views/label/View.vue
@@ -1,9 +1,6 @@
 <template>
   <!-- ============================================================= HERO -->
-  <section
-    ref="heroRoot"
-    class="label-hero relative overflow-hidden"
-  >
+  <section class="label-hero relative overflow-hidden">
     <!-- Layered decorative background: gradient wash + blobs -->
     <div
       aria-hidden="true"
@@ -120,10 +117,7 @@
   </section>
 
   <!-- ====================================================== SCALE SECTION -->
-  <section
-    ref="scaleRoot"
-    class="relative overflow-hidden py-20 md:py-28"
-  >
+  <section class="relative overflow-hidden py-20 md:py-28">
     <div
       aria-hidden="true"
       class="label-blob label-blob-soft absolute top-10 -left-24 z-0"
@@ -160,7 +154,6 @@
         <article
           v-for="(tranche, index) in TRANCHES"
           :key="tranche.key"
-          ref="trancheCards"
           class="label-tranche group border-on-surface/10 relative flex flex-col gap-5 overflow-hidden rounded-3xl border p-6"
           :class="[tranche.surfaceClass, { 'label-tranche-revealed': scaleRevealed }]"
           :style="{ '--reveal-delay': `${0.1 + index * 0.14}s` }"
@@ -218,10 +211,7 @@
   </section>
 
   <!-- =============================================== GAMIFICATION SECTION -->
-  <section
-    ref="gamificationRoot"
-    class="relative overflow-hidden py-20 md:py-28"
-  >
+  <section class="relative overflow-hidden py-20 md:py-28">
     <div
       aria-hidden="true"
       class="label-blob label-blob-soft absolute -right-24 bottom-0 z-0"
@@ -270,7 +260,6 @@
           progress around a scoreboard. Midjourney prompt in ClickUp.
         -->
         <div
-          ref="gamificationFigure"
           class="label-reveal-figure order-first lg:order-last"
           :class="{ 'label-figure-revealed': gamificationRevealed }"
         >
@@ -292,10 +281,7 @@
   </section>
 
   <!-- ===================================================== VISION SECTION -->
-  <section
-    ref="visionRoot"
-    class="relative overflow-hidden py-20 md:py-28"
-  >
+  <section class="relative overflow-hidden py-20 md:py-28">
     <Container class="relative z-10">
       <div class="grid items-center gap-12 lg:grid-cols-2">
         <!--
@@ -303,7 +289,6 @@
           product, in soft natural light. Midjourney prompt in ClickUp.
         -->
         <div
-          ref="visionFigure"
           class="label-reveal-figure"
           :class="{ 'label-figure-revealed': visionRevealed }"
         >
@@ -347,7 +332,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { ref, type Ref } from 'vue';
 import { useIntersectionObserver } from '@vueuse/core';
 
 import { usePrefixedI18n } from '@lychen/vue-i18n/composables/useI18nExtended';
@@ -406,8 +391,7 @@ const GAMIFICATION_EXAMPLES = [
   { level: 8 },
 ] as const;
 
-function useReveal(threshold = 0.25) {
-  const target = ref<HTMLElement | null>(null);
+function useReveal(target: Ref<HTMLElement | null>, threshold = 0.25) {
   const revealed = ref(false);
   useIntersectionObserver(
     target,
@@ -418,22 +402,17 @@ function useReveal(threshold = 0.25) {
     },
     { threshold },
   );
-  return { target, revealed };
+  return revealed;
 }
 
-const { target: heroCopy, revealed: heroRevealed } = useReveal(0.1);
-const { target: scaleHeading, revealed: scaleRevealed } = useReveal(0.2);
-const { target: gamificationCopy, revealed: gamificationRevealed } = useReveal(0.2);
-const { target: visionCopy, revealed: visionRevealed } = useReveal(0.2);
-
-// Refs used only as scroll/animation anchors (kept for clarity & future parallax).
-const heroRoot = ref<HTMLElement | null>(null);
-const scaleRoot = ref<HTMLElement | null>(null);
-const trancheCards = ref<HTMLElement[] | null>(null);
-const gamificationRoot = ref<HTMLElement | null>(null);
-const gamificationFigure = ref<HTMLElement | null>(null);
-const visionRoot = ref<HTMLElement | null>(null);
-const visionFigure = ref<HTMLElement | null>(null);
+const heroCopy = ref<HTMLElement | null>(null);
+const heroRevealed = useReveal(heroCopy, 0.1);
+const scaleHeading = ref<HTMLElement | null>(null);
+const scaleRevealed = useReveal(scaleHeading, 0.2);
+const gamificationCopy = ref<HTMLElement | null>(null);
+const gamificationRevealed = useReveal(gamificationCopy, 0.2);
+const visionCopy = ref<HTMLElement | null>(null);
+const visionRevealed = useReveal(visionCopy, 0.2);
 </script>
 
 <style scoped>

--- a/projects/website/src/views/label/i18n/en-US.json
+++ b/projects/website/src/views/label/i18n/en-US.json
@@ -5,29 +5,55 @@
   },
   "title": "Robust Label",
   "hero": {
-    "title": "Robust: The Scale of Resilience and Autonomy",
-    "description": "A single label to measure robustness, from transition to the regeneration of life. A unique scale from 1 to 10 for all systems (cities, companies, associations, products)."
+    "badge": "The label of life",
+    "title": {
+      "prepend": "Robust: the scale of ",
+      "key_word": "resilience",
+      "append": " and autonomy"
+    },
+    "description": "A single label to measure robustness, from transition to the regeneration of life. A unique scale from 1 to 10 for all systems (cities, companies, associations, products).",
+    "scale_hint": "Transition → Preservation → Regeneration",
+    "stats": {
+      "levels": { "value": "1 → 10", "label": "Robustness levels" },
+      "tranches": { "value": "3", "label": "Major stages" },
+      "scope": { "value": "∞", "label": "Systems covered" }
+    }
+  },
+  "scale": {
+    "kicker": "The Robust scale",
+    "title": {
+      "prepend": "From transition to the ",
+      "key_word": "regeneration",
+      "append": " of life"
+    },
+    "description": "Each level marks a concrete step forward. Progress happens one stage at a time, from a first burst of transition to actively contributing to the restoration of ecosystems."
   },
   "tranches": {
     "transition": {
       "title": "Transition",
       "subtitle": "Levels 1 to 3",
-      "description": "The system initiates its model change. It implements initial initiatives to reduce negative impact and move towards sustainable practices."
+      "description": "The system initiates its model change. It implements initial initiatives to reduce negative impact and move towards sustainable practices.",
+      "image_alt": "A field at the start of its conversion, with first grass strips and replanted hedgerows"
     },
     "preservation": {
       "title": "Preservation",
       "subtitle": "Levels 4 to 7",
-      "description": "The system preserves the ecosystem. It has reached a balance where its activities no longer harm the environment and maintain existing resources."
+      "description": "The system preserves the ecosystem. It has reached a balance where its activities no longer harm the environment and maintain existing resources.",
+      "image_alt": "Cultivated plots in balance with preserved groves and ponds"
     },
     "regeneration": {
       "title": "Regeneration",
       "subtitle": "Levels 8 to 10",
-      "description": "The system regenerates the surrounding ecosystem. It aims for complete autonomy and actively contributes to the restoration of life and biodiversity."
+      "description": "The system regenerates the surrounding ecosystem. It aims for complete autonomy and actively contributes to the restoration of life and biodiversity.",
+      "image_alt": "A thriving agroecological farm seen from above, a mosaic of crops and forests"
     }
   },
   "gamification": {
-    "title": "Coherent & Measurable Gamification",
+    "kicker": "Comparable & measurable",
+    "title": "Coherent & measurable gamification",
     "description": "The Robust Label allows comparing and validating the efforts of each actor, whatever their nature. The larger the system, the harder the level is to reach, highlighting agile small local initiatives.",
+    "image_alt": "A local community celebrating their territory's progress around a scoreboard",
+    "examples_title": "A few scores",
     "examples": {
       "0": { "role": "Local Association", "points": "Level 6 (100 pts)" },
       "1": { "role": "Company Y", "points": "Level 4 (20 pts)" },
@@ -36,7 +62,9 @@
     }
   },
   "vision": {
-    "title": "A Unique Vision",
-    "description": "By speaking only of 'Robust Level X', we simplify communication while maintaining scientific precision on real impact. It is a universal recognition tool for ecological transition."
+    "kicker": "A shared language",
+    "title": "A unique vision",
+    "description": "By speaking only of 'Robust Level X', we simplify communication while maintaining scientific precision on real impact. It is a universal recognition tool for ecological transition.",
+    "image_alt": "A Robust label proudly displayed on a local product, in soft light"
   }
 }

--- a/projects/website/src/views/label/i18n/fr-FR.json
+++ b/projects/website/src/views/label/i18n/fr-FR.json
@@ -5,29 +5,55 @@
   },
   "title": "Label Robust",
   "hero": {
-    "title": "Robust : L'Échelle de la Résilience et de l'Autonomie",
-    "description": "Un seul label pour mesurer la robustesse, de la transition à la régénération du vivant. Une échelle unique de 1 à 10 pour tous les systèmes (villes, entreprises, associations, produits)."
+    "badge": "Le label du vivant",
+    "title": {
+      "prepend": "Robust : l'échelle de la ",
+      "key_word": "résilience",
+      "append": " et de l'autonomie"
+    },
+    "description": "Un seul label pour mesurer la robustesse, de la transition à la régénération du vivant. Une échelle unique de 1 à 10 pour tous les systèmes (villes, entreprises, associations, produits).",
+    "scale_hint": "Transition → Préservation → Régénération",
+    "stats": {
+      "levels": { "value": "1 → 10", "label": "Niveaux de robustesse" },
+      "tranches": { "value": "3", "label": "Grandes étapes" },
+      "scope": { "value": "∞", "label": "Systèmes concernés" }
+    }
+  },
+  "scale": {
+    "kicker": "L'échelle Robust",
+    "title": {
+      "prepend": "De la transition à la ",
+      "key_word": "régénération",
+      "append": " du vivant"
+    },
+    "description": "Chaque niveau marque une avancée concrète. On progresse pas à pas, d'un premier sursaut de transition jusqu'à une contribution active à la restauration des écosystèmes."
   },
   "tranches": {
     "transition": {
       "title": "Transition",
       "subtitle": "Niveaux 1 à 3",
-      "description": "Le système amorce son changement de modèle. Il met en place les premières initiatives pour réduire son impact négatif et s'orienter vers des pratiques durables."
+      "description": "Le système amorce son changement de modèle. Il met en place les premières initiatives pour réduire son impact négatif et s'orienter vers des pratiques durables.",
+      "image_alt": "Champ en début de conversion, premières bandes enherbées et haies replantées"
     },
     "preservation": {
       "title": "Préservation",
       "subtitle": "Niveaux 4 à 7",
-      "description": "Le système préserve l'écosystème. Il a atteint un équilibre où ses activités ne nuisent plus à l'environnement et permettent de maintenir les ressources existantes."
+      "description": "Le système préserve l'écosystème. Il a atteint un équilibre où ses activités ne nuisent plus à l'environnement et permettent de maintenir les ressources existantes.",
+      "image_alt": "Parcelles cultivées en équilibre avec des bosquets et des mares préservées"
     },
     "regeneration": {
       "title": "Régénération",
       "subtitle": "Niveaux 8 à 10",
-      "description": "Le système régénère l'écosystème qui l'entoure. Il vise une autonomie complète et contribue activement à la restauration du vivant et de la biodiversité."
+      "description": "Le système régénère l'écosystème qui l'entoure. Il vise une autonomie complète et contribue activement à la restauration du vivant et de la biodiversité.",
+      "image_alt": "Ferme agroécologique foisonnante vue du ciel, mosaïque de cultures et de forêts"
     }
   },
   "gamification": {
-    "title": "Gamification Cohérente & Mesurable",
+    "kicker": "Comparable & mesurable",
+    "title": "Gamification cohérente & mesurable",
     "description": "Le Label Robust permet de comparer et valider les efforts de chaque acteur, quelle que soit sa nature. Plus le système est gros, plus le niveau est complexe à atteindre, mettant en évidence les petites initiatives locales agiles.",
+    "image_alt": "Communauté locale célébrant la progression de son territoire autour d'un tableau de scores",
+    "examples_title": "Quelques scores",
     "examples": {
       "0": { "role": "Asso Locale", "points": "Niveau 6 (100 pts)" },
       "1": { "role": "Entreprise Y", "points": "Niveau 4 (20 pts)" },
@@ -36,7 +62,9 @@
     }
   },
   "vision": {
-    "title": "Une Vision Unique",
-    "description": "En parlant uniquement de 'Robust Niveau X', nous simplifions la communication tout en gardant une précision scientifique sur l'impact réel. C'est un outil de reconnaissance universel pour la transition écologique."
+    "kicker": "Un langage commun",
+    "title": "Une vision unique",
+    "description": "En parlant uniquement de 'Robust Niveau X', nous simplifions la communication tout en gardant une précision scientifique sur l'impact réel. C'est un outil de reconnaissance universel pour la transition écologique.",
+    "image_alt": "Étiquette Robust apposée fièrement sur un produit local, sous une lumière douce"
   }
 }

--- a/projects/website/src/views/mission/View.vue
+++ b/projects/website/src/views/mission/View.vue
@@ -1,58 +1,343 @@
 <template>
-  <Container class="flex flex-col items-center gap-8 pt-20 text-center">
-    <Title variant="h1">{{ t('meta.title') }}</Title>
-    <Paragraph>{{ t('meta.description') }}</Paragraph>
-  </Container>
+  <!-- HERO / INTRO BAND -->
+  <section class="mission-hero relative isolate overflow-hidden">
+    <div
+      aria-hidden="true"
+      class="mission-blob mission-blob-primary absolute z-0"
+    />
+    <div
+      aria-hidden="true"
+      class="mission-blob mission-blob-tertiary absolute z-0"
+    />
 
-  <Container class="flex flex-col items-center gap-8 pt-20 text-center">
-    <Title variant="h2">{{ t('goals.title') }}</Title>
-    <Paragraph>{{ t('goals.description') }}</Paragraph>
-    <div class="grid grid-cols-2 grid-rows-2 items-stretch gap-8">
-      <div
-        class="border-on-surface/20 row-span-2 flex flex-col items-center justify-center gap-4 rounded-2xl border p-8"
-      >
-        <div class="bg-surface-2 h-48 w-full rounded-xl opacity-20"></div>
-        <Title variant="h3">{{ t('goals.food.title') }}</Title>
-        <p class="opacity-60">
-          {{ t('goals.food.description') }}
-        </p>
-      </div>
-      <div
-        class="border-on-surface/20 flex flex-col items-center justify-center gap-4 rounded-2xl border p-8"
-      >
-        <Title variant="h3">{{ t('goals.biodiversity.title') }}</Title>
-        <p class="opacity-60">
-          {{ t('goals.biodiversity.description') }}
-        </p>
-      </div>
-      <div
-        class="border-on-surface/20 flex flex-col items-center justify-center gap-4 rounded-2xl border p-8"
-      >
-        <Title variant="h3">{{ t('goals.social.title') }}</Title>
-        <p class="opacity-60">
-          {{ t('goals.social.description') }}
-        </p>
-      </div>
-    </div>
-  </Container>
+    <svg
+      aria-hidden="true"
+      class="mission-ridge absolute inset-x-0 bottom-0 z-0 h-[28svh] w-full dark:brightness-[0.55]"
+      viewBox="0 0 1440 320"
+      preserveAspectRatio="none"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <linearGradient
+          id="mission-ridge-gradient"
+          x1="0"
+          y1="0"
+          x2="0"
+          y2="1"
+        >
+          <stop
+            offset="0"
+            stop-color="oklch(0.62 0.05 150 / 0.35)"
+          />
+          <stop
+            offset="1"
+            stop-color="oklch(0.45 0.055 145 / 0.12)"
+          />
+        </linearGradient>
+      </defs>
+      <path
+        d="M0 170 C 110 150, 230 112, 360 120 C 490 128, 560 178, 690 186 C 820 194, 900 148, 1020 140 C 1140 132, 1240 162, 1340 170 C 1380 173, 1410 174, 1440 174 L 1440 320 L 0 320 Z"
+        fill="url(#mission-ridge-gradient)"
+      />
+    </svg>
 
-  <Container class="flex flex-col items-center gap-8 pt-20 text-center">
-    <Title variant="h2">{{ t('status.title') }}</Title>
-    <Paragraph>{{ t('status.description') }}</Paragraph>
-    <p class="mx-auto max-w-3xl text-justify whitespace-pre-line opacity-60">
-      {{ t('status.content') }}
-    </p>
-  </Container>
+    <Container class="relative z-10 flex flex-col items-center gap-6 pt-28 pb-20 text-center">
+      <span
+        class="border-on-surface/15 bg-surface-container-low inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-xs font-semibold tracking-widest uppercase backdrop-blur-md"
+      >
+        <span class="bg-primary size-1.5 animate-pulse rounded-full" />
+        {{ t('hero.badge') }}
+      </span>
+      <Title
+        variant="h1"
+        class="font-lexend max-w-4xl text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.05] font-extrabold tracking-tight"
+        >{{ t('hero.titlePrepend')
+        }}<span
+          class="from-primary bg-gradient-to-r via-[oklch(0.65_0.1_150)] to-[oklch(0.55_0.12_180)] bg-clip-text text-transparent"
+          >{{ t('hero.titleHighlight') }}</span
+        >{{ t('hero.titleAppend') }}</Title
+      >
+      <Paragraph
+        variant="website-highlight"
+        class="max-w-2xl opacity-80"
+        >{{ t('meta.description') }}</Paragraph
+      >
+
+      <!-- IMAGE PLACEHOLDER: wide hero banner — sunlit regenerative farmland meeting wild meadow, aerial — see Midjourney prompt in PR/ClickUp -->
+      <div
+        aria-hidden="true"
+        class="mission-photo ring-on-surface/10 relative mt-6 flex aspect-[16/7] w-full max-w-4xl items-end overflow-hidden rounded-3xl shadow-xl ring-1"
+      >
+        <div class="mission-photo-grade absolute inset-0" />
+        <span
+          class="bg-surface/85 text-on-surface absolute bottom-3 left-3 flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-bold backdrop-blur-md"
+        >
+          <span class="bg-primary size-1.5 rounded-full" />
+          {{ t('hero.imageLabel') }}
+        </span>
+      </div>
+    </Container>
+  </section>
+
+  <!-- THREE MISSION PILLARS -->
+  <section class="relative">
+    <Container class="flex flex-col items-center gap-12 pt-20 text-center">
+      <div
+        ref="goalsCopy"
+        class="mission-reveal flex flex-col items-center gap-4"
+        :class="{ 'mission-revealed': goalsRevealed }"
+      >
+        <span class="text-primary text-xs font-bold tracking-[0.2em] uppercase">{{
+          t('goals.kicker')
+        }}</span>
+        <Title
+          variant="h2"
+          class="font-lexend text-4xl font-extrabold tracking-tight md:text-5xl"
+          >{{ t('goals.title') }}</Title
+        >
+        <Paragraph
+          variant="website-highlight"
+          class="max-w-2xl opacity-80"
+          >{{ t('goals.description') }}</Paragraph
+        >
+      </div>
+
+      <div class="grid w-full grid-cols-1 gap-6 text-left md:grid-cols-3">
+        <article
+          v-for="(pillar, index) in PILLARS"
+          :key="pillar.key"
+          class="mission-card border-on-surface/10 bg-surface-container-low group relative flex flex-col gap-5 overflow-hidden rounded-3xl border p-6 shadow-sm transition-shadow duration-300 hover:shadow-xl"
+          :class="{ 'mission-revealed': goalsRevealed }"
+          :style="{ '--reveal-delay': `${0.1 + index * 0.12}s` }"
+        >
+          <!-- IMAGE PLACEHOLDER: pillar photo — see Midjourney prompt in PR/ClickUp -->
+          <div
+            aria-hidden="true"
+            class="mission-photo ring-on-surface/10 relative flex aspect-[4/3] w-full items-end overflow-hidden rounded-2xl ring-1"
+            :class="pillar.photoClass"
+          >
+            <div class="mission-photo-grade absolute inset-0" />
+            <span
+              class="bg-surface/85 text-on-surface absolute bottom-2.5 left-2.5 flex items-center gap-1.5 rounded-full px-3 py-1 text-[11px] font-bold backdrop-blur-md"
+            >
+              <span
+                class="size-1.5 rounded-full"
+                :class="pillar.dotClass"
+              />
+              {{ t(`goals.${pillar.key}.label`) }}
+            </span>
+          </div>
+
+          <div
+            class="ring-on-surface/10 bg-surface flex size-11 items-center justify-center rounded-2xl shadow-sm ring-1"
+            :class="pillar.iconWrapClass"
+          >
+            <component
+              :is="pillar.icon"
+              class="size-5"
+              :class="pillar.iconClass"
+            />
+          </div>
+
+          <Title
+            variant="h3"
+            class="font-lexend text-xl font-bold"
+            >{{ t(`goals.${pillar.key}.title`) }}</Title
+          >
+          <p class="opacity-70">
+            {{ t(`goals.${pillar.key}.description`) }}
+          </p>
+        </article>
+      </div>
+    </Container>
+  </section>
+
+  <!-- OFFICIAL FRAMEWORK / STATUS -->
+  <section class="relative">
+    <Container class="flex flex-col items-center pt-24 pb-20">
+      <div
+        ref="statusCopy"
+        class="mission-reveal mission-status-panel border-on-surface/10 relative w-full max-w-4xl overflow-hidden rounded-3xl border p-8 shadow-sm md:p-12"
+        :class="{ 'mission-revealed': statusRevealed }"
+      >
+        <div
+          aria-hidden="true"
+          class="mission-blob mission-blob-tertiary !top-auto !right-[-15%] !bottom-[-20%] !left-auto absolute z-0 opacity-60"
+        />
+        <div class="relative z-10 flex flex-col items-center gap-5 text-center">
+          <span class="text-primary text-xs font-bold tracking-[0.2em] uppercase">{{
+            t('status.kicker')
+          }}</span>
+          <Title
+            variant="h2"
+            class="font-lexend text-3xl font-extrabold tracking-tight md:text-4xl"
+            >{{ t('status.title') }}</Title
+          >
+          <Paragraph
+            variant="website-highlight"
+            class="max-w-2xl opacity-80"
+            >{{ t('status.description') }}</Paragraph
+          >
+          <p class="mt-2 max-w-3xl text-justify whitespace-pre-line opacity-70">
+            {{ t('status.content') }}
+          </p>
+        </div>
+      </div>
+    </Container>
+  </section>
 </template>
 
 <script lang="ts" setup>
+import { ref } from 'vue';
+import { useIntersectionObserver } from '@vueuse/core';
+
 import { usePrefixedI18n } from '@lychen/vue-i18n/composables/useI18nExtended';
+import { useExtendedHead } from '@lychen/vue-unhead-composables/useExtendedHead';
 import { CONFIG } from './i18n';
 import Container from '@lychen/vue-components-website/container/Container.vue';
 import Title from '@lychen/vue-components-website/title/Title.vue';
 import Paragraph from '@lychen/vue-components-website/paragraph/Paragraph.vue';
-import { useExtendedHead } from '@lychen/vue-unhead-composables/useExtendedHead';
+import IconSprout from '@lychen/vue-icons/IconSprout.vue';
+import IconEarth from '@lychen/vue-icons/IconEarth.vue';
+import IconHeartHandshake from '@lychen/vue-icons/IconHeartHandshake.vue';
 
 const { t } = usePrefixedI18n(CONFIG);
 useExtendedHead(t);
+
+const PILLARS = [
+  {
+    key: 'food',
+    icon: IconSprout,
+    dotClass: 'bg-primary',
+    iconClass: 'text-primary',
+    iconWrapClass: '',
+    photoClass: 'mission-photo-food',
+  },
+  {
+    key: 'biodiversity',
+    icon: IconEarth,
+    dotClass: 'bg-positive',
+    iconClass: 'text-positive',
+    iconWrapClass: '',
+    photoClass: 'mission-photo-biodiversity',
+  },
+  {
+    key: 'social',
+    icon: IconHeartHandshake,
+    dotClass: 'bg-tertiary',
+    iconClass: 'text-tertiary',
+    iconWrapClass: '',
+    photoClass: 'mission-photo-social',
+  },
+] as const;
+
+function useReveal() {
+  const target = ref<HTMLElement | null>(null);
+  const revealed = ref(false);
+  useIntersectionObserver(
+    target,
+    (entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        revealed.value = true;
+      }
+    },
+    { threshold: 0.25 },
+  );
+  return { target, revealed };
+}
+
+const { target: goalsCopy, revealed: goalsRevealed } = useReveal();
+const { target: statusCopy, revealed: statusRevealed } = useReveal();
 </script>
+
+<style scoped>
+.mission-blob {
+  width: clamp(280px, 38vw, 560px);
+  height: clamp(280px, 38vw, 560px);
+  border-radius: 9999px;
+  filter: blur(80px);
+  pointer-events: none;
+}
+
+.mission-blob-primary {
+  top: -10%;
+  left: -12%;
+  background: var(--color-primary);
+  opacity: 0.14;
+}
+
+.mission-blob-tertiary {
+  top: 10%;
+  right: -14%;
+  background: var(--color-tertiary);
+  opacity: 0.12;
+}
+
+/* Styled placeholder blocks standing in for photographs. */
+.mission-photo {
+  background:
+    radial-gradient(120% 120% at 20% 0%, oklch(0.88 0.13 131 / 0.55), transparent 60%),
+    linear-gradient(150deg, oklch(0.72 0.09 150) 0%, oklch(0.42 0.07 145) 100%);
+}
+
+.mission-photo-grade {
+  background: linear-gradient(180deg, transparent 45%, rgb(0 0 0 / 0.28) 100%);
+}
+
+.mission-photo-food {
+  background:
+    radial-gradient(120% 120% at 20% 0%, oklch(0.9 0.13 128 / 0.6), transparent 60%),
+    linear-gradient(150deg, oklch(0.74 0.1 135) 0%, oklch(0.44 0.08 140) 100%);
+}
+
+.mission-photo-biodiversity {
+  background:
+    radial-gradient(120% 120% at 20% 0%, oklch(0.85 0.1 165 / 0.6), transparent 60%),
+    linear-gradient(150deg, oklch(0.68 0.09 175) 0%, oklch(0.4 0.07 185) 100%);
+}
+
+.mission-photo-social {
+  background:
+    radial-gradient(120% 120% at 20% 0%, oklch(0.86 0.11 70 / 0.6), transparent 60%),
+    linear-gradient(150deg, oklch(0.72 0.1 60) 0%, oklch(0.46 0.09 45) 100%);
+}
+
+.mission-status-panel {
+  background:
+    radial-gradient(140% 120% at 0% 0%, oklch(0.88 0.05 150 / 0.12), transparent 55%),
+    var(--color-surface-container-low);
+}
+
+/* Scroll-reveal. */
+.mission-reveal,
+.mission-card {
+  opacity: 0;
+  translate: 0 26px;
+  transition:
+    opacity 0.7s ease,
+    translate 0.7s ease;
+}
+
+.mission-card {
+  transition-delay: var(--reveal-delay, 0s);
+}
+
+.mission-revealed {
+  opacity: 1;
+  translate: 0 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mission-reveal,
+  .mission-card {
+    opacity: 1;
+    translate: 0 0;
+    transition: none;
+  }
+
+  .mission-blob-primary {
+    animation: none;
+  }
+}
+</style>

--- a/projects/website/src/views/mission/View.vue
+++ b/projects/website/src/views/mission/View.vue
@@ -189,7 +189,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { ref, type Ref } from 'vue';
 import { useIntersectionObserver } from '@vueuse/core';
 
 import { usePrefixedI18n } from '@lychen/vue-i18n/composables/useI18nExtended';
@@ -232,8 +232,7 @@ const PILLARS = [
   },
 ] as const;
 
-function useReveal() {
-  const target = ref<HTMLElement | null>(null);
+function useReveal(target: Ref<HTMLElement | null>) {
   const revealed = ref(false);
   useIntersectionObserver(
     target,
@@ -244,11 +243,13 @@ function useReveal() {
     },
     { threshold: 0.25 },
   );
-  return { target, revealed };
+  return revealed;
 }
 
-const { target: goalsCopy, revealed: goalsRevealed } = useReveal();
-const { target: statusCopy, revealed: statusRevealed } = useReveal();
+const goalsCopy = ref<HTMLElement | null>(null);
+const goalsRevealed = useReveal(goalsCopy);
+const statusCopy = ref<HTMLElement | null>(null);
+const statusRevealed = useReveal(statusCopy);
 </script>
 
 <style scoped>

--- a/projects/website/src/views/mission/i18n/en-US.json
+++ b/projects/website/src/views/mission/i18n/en-US.json
@@ -3,24 +3,37 @@
     "title": "A Mission for Resilience",
     "description": "We put technology at the service of life. Our ambition is to provide territories with the tools to understand, preserve, and regenerate their ecosystems."
   },
+  "hero": {
+    "badge": "Our Mission",
+    "titlePrepend": "A Mission for ",
+    "titleHighlight": "Resilience",
+    "titleAppend": "",
+    "scroll_hint": "Discover our areas of impact",
+    "imageLabel": "Life & territories"
+  },
   "goals": {
     "title": "Our Areas of Impact",
+    "kicker": "Three pillars",
     "description": "To meet the challenges of our century, we structure our action around three complementary pillars.",
     "food": {
       "title": "Food Sovereignty",
+      "label": "Local production",
       "description": "Deploying tools for local production that is resilient and respectful of biodiversity."
     },
     "biodiversity": {
       "title": "Protecting Life",
+      "label": "Territorial data",
       "description": "Observing and quantifying biodiversity to better protect it through territorial data."
     },
     "social": {
       "title": "Social & Economic Bond",
+      "label": "Local cooperation",
       "description": "Making digital technology a lever for cooperation, solidarity, and sharing among local actors."
     }
   },
   "status": {
     "title": "Official Framework",
+    "kicker": "Our statutes",
     "description": "Our commitment is enshrined in our statutes, guaranteeing the longevity of our mission.",
     "content": "The purpose of this association is to promote the resilience of territories in the face of environmental and societal challenges.\n\nThe activities envisaged to achieve this objective (without limitation) specifically include:\n- Developing and distributing digital tools (software, platforms, databases).\n- Collecting, analyzing, and sharing territorial data.\n- Promoting ethical and sustainable technology.\n- Offering consulting, training, and research services.\n\nAll other means likely to contribute to the realization of its social object.\n\nThe association has an economic activity."
   }

--- a/projects/website/src/views/mission/i18n/fr-FR.json
+++ b/projects/website/src/views/mission/i18n/fr-FR.json
@@ -3,24 +3,37 @@
     "title": "Une Mission pour la Résilience",
     "description": "Nous mettons la technologie au service du vivant. Notre ambition est de fournir aux territoires les outils pour comprendre, préserver et régénérer leurs écosystèmes."
   },
+  "hero": {
+    "badge": "Notre Mission",
+    "titlePrepend": "Une Mission pour ",
+    "titleHighlight": "la Résilience",
+    "titleAppend": "",
+    "scroll_hint": "Découvrir nos axes d'impact",
+    "imageLabel": "Vivant & territoires"
+  },
   "goals": {
     "title": "Nos Axes d'Impact",
+    "kicker": "Trois piliers",
     "description": "Pour relever les défis de notre siècle, nous structurons notre action autour de trois piliers complémentaires.",
     "food": {
       "title": "Souveraineté Alimentaire",
+      "label": "Production locale",
       "description": "Déployer des outils pour une production locale, résiliente et respectueuse de la biodiversité."
     },
     "biodiversity": {
       "title": "Protection du Vivant",
+      "label": "Donnée territoriale",
       "description": "Observer et quantifier la biodiversité pour mieux la protéger grâce à la donnée territoriale."
     },
     "social": {
       "title": "Lien Social & Économique",
+      "label": "Coopération locale",
       "description": "Faire du numérique un levier de coopération, de solidarité et de partage entre les acteurs locaux."
     }
   },
   "status": {
     "title": "Cadre Officiel",
+    "kicker": "Nos statuts",
     "description": "Notre engagement est inscrit dans nos statuts, garantissant la pérennité de notre mission.",
     "content": "Cette association a pour objet de favoriser la résilience des territoires face aux enjeux environnementaux et sociétaux.\n\nLes activités envisagées pour atteindre cet objectif (sans limitation) sont notamment :\n- Développer et diffuser des outils numériques (logiciels, plateformes, bases de données).\n- Collecter, analyser et partager des données territoriales.\n- Promouvoir une technologie éthique et durable.\n- Offrir des services de conseil, de formation et de recherche.\n\nTous les autres moyens susceptibles de concourir à la réalisation de son objet social.\n\nL'association a une activité économique."
   }


### PR DESCRIPTION
## Overview

This PR bundles three website tasks (all `project:website`).

### 1. Fix — SDG icon missing on the home page first load
The sustainable-development-goals icon in `PageHomeODD.vue` used a **relative** `src` (`sustainable-development-goals/icons/...`). On the locale-prefixed home route (e.g. `/fr-FR/`) the browser resolved it against the current path (`/fr-FR/sustainable-development-goals/...`) and 404'd, so the icon only appeared after a client-side navigation. The sibling photo worked because it's a Vite-imported absolute URL. Fixed by referencing the public asset with a root-absolute path.

### 2. Redesign — Mission page (`/about/mission`)
Transformed the plain page into a richer, scrollable narrative matching the home page design language:
- graphic hero with animated badge, decorative blobs / SVG ridge and a gradient-highlighted keyword title (dark-mode aware)
- the three mission pillars (food / biodiversity / social) as polished cards with icons, styled image placeholders and labels
- the association status narrative in a highlighted panel
- scroll-reveal animations via `IntersectionObserver`, with a `prefers-reduced-motion` fallback

### 3. Redesign — Label page (`/label`)
Reworked the Robust label page into a rich, animated scrollable experience:
- graphic hero with badge, gradient-highlighted title, decorative blobs / gradient wash / SVG ridge and a `1→10 / 3 / ∞` stats grid
- three-tranche scale (transition / preservation / regeneration) keeps its `RobustLabel` badges, now in styled cards with gradient image placeholders, tranche icons and colored surfaces
- gamification and vision rebuilt as alternating placeholder/text rows
- scroll-reveal animations with staggered delays and a `prefers-reduced-motion` fallback

## Notes
- **Images are intentionally placeholders.** Each image spot is a styled, `aria-hidden` block documented with an inline HTML comment. Midjourney prompts for the intended photos have been posted to the respective tickets so final imagery can be generated and dropped in.
- i18n: `fr-FR` / `en-US` kept in perfect key parity for both pages.
- Conventions respected: `<script setup lang="ts">`, strict TS, no `console.log`, Tailwind v4, SFC order.

## Verification
- i18n JSON parses and key sets match across locales for both pages.
- All imported icons / components / composables resolve to existing files.
- All static `t()` keys used in the templates exist in the locale files.
- Toolchain (`moon`/`proto`) is not available in this environment, so ESLint/build were not run here — please rely on CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_013xMVq5yvZdw2h3EWDeksGd)_