### PR TITLE
feat(website): add link to espace.lychen.org on home ecosystem section

### DIFF
--- a/libs/vue/applications/composables/useApplicationsCatalog.ts
+++ b/libs/vue/applications/composables/useApplicationsCatalog.ts
@@ -10,6 +10,7 @@ export type TranslatedApplication = {
   description: string;
   state: string;
   alias: ApplicationAlias;
+  url?: string;
 };
 
 export function useApplicationsCatalog(): {
@@ -26,6 +27,7 @@ export function useApplicationsCatalog(): {
       description: t(`${alias}.description`),
       state: t(`state.${APPLICATIONS[alias].state}`),
       alias,
+      url: APPLICATIONS[alias].url,
     };
   }
 

--- a/libs/vue/applications/constants/Applications.ts
+++ b/libs/vue/applications/constants/Applications.ts
@@ -7,7 +7,7 @@ import {
   type ApplicationState,
 } from '@lychen/typescript-applications/constants/ApplicationState';
 
-export const APPLICATIONS: Record<ApplicationAlias, { state: ApplicationState }> = {
+export const APPLICATIONS: Record<ApplicationAlias, { state: ApplicationState; url?: string }> = {
   [APPLICATION_ALIAS.Tera]: { state: APPLICATION_STATE.Development },
   [APPLICATION_ALIAS.Myko]: { state: APPLICATION_STATE.Funding },
   [APPLICATION_ALIAS.Kiro]: { state: APPLICATION_STATE.Funding },
@@ -17,5 +17,5 @@ export const APPLICATIONS: Record<ApplicationAlias, { state: ApplicationState }>
   [APPLICATION_ALIAS.Vara]: { state: APPLICATION_STATE.Funding },
   [APPLICATION_ALIAS.Novi]: { state: APPLICATION_STATE.Funding },
   [APPLICATION_ALIAS.Robust]: { state: APPLICATION_STATE.Funding },
-  [APPLICATION_ALIAS.Espace]: { state: APPLICATION_STATE.Development },
+  [APPLICATION_ALIAS.Espace]: { state: APPLICATION_STATE.Development, url: 'https://espace.lychen.org' },
 };

--- a/projects/website/src/views/home/PageHomeUseCases.vue
+++ b/projects/website/src/views/home/PageHomeUseCases.vue
@@ -130,9 +130,13 @@
         ref="gridRef"
         class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
       >
-        <article
+        <component
+          :is="application.url ? 'a' : 'article'"
           v-for="(application, index) in applications"
           :key="application.alias"
+          :href="application.url"
+          :target="application.url ? '_blank' : undefined"
+          :rel="application.url ? 'noopener noreferrer' : undefined"
           class="ecosystem-app group flex flex-col gap-3 rounded-3xl border p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
           :class="[
             isFlagship(application.alias)
@@ -154,15 +158,22 @@
                 >{{ application.title }}</Title
               >
             </div>
-            <span
-              class="rounded-full px-2.5 py-0.5 text-[11px] font-semibold whitespace-nowrap"
-              :class="
-                isFlagship(application.alias)
-                  ? 'bg-white/15 text-white'
-                  : 'bg-surface-container text-on-surface/60'
-              "
-              >{{ application.state }}</span
-            >
+            <div class="flex items-center gap-2">
+              <span
+                class="rounded-full px-2.5 py-0.5 text-[11px] font-semibold whitespace-nowrap"
+                :class="
+                  isFlagship(application.alias)
+                    ? 'bg-white/15 text-white'
+                    : 'bg-surface-container text-on-surface/60'
+                "
+                >{{ application.state }}</span
+              >
+              <IconArrowUpRight
+                v-if="application.url"
+                class="size-3.5 shrink-0 opacity-60"
+                :class="isFlagship(application.alias) ? 'text-white' : 'text-on-surface'"
+              />
+            </div>
           </div>
           <p
             class="line-clamp-3 text-sm"
@@ -170,7 +181,7 @@
           >
             {{ application.description }}
           </p>
-        </article>
+        </component>
       </div>
 
       <RouterLink :to="{ name: ROUTE_APPLICATIONS.name }">
@@ -207,6 +218,7 @@ import IconBadgeCheck from '@lychen/vue-icons/IconBadgeCheck.vue';
 import IconShare2 from '@lychen/vue-icons/IconShare2.vue';
 import IconGithub from '@lychen/vue-icons/IconGithub.vue';
 import IconLink from '@lychen/vue-icons/IconLink.vue';
+import IconArrowUpRight from '@lychen/vue-icons/IconArrowUpRight.vue';
 
 const { t } = usePrefixedI18n(CONFIG);
 const { opiniatedApplicationsList: applications } = useApplicationsCatalog();


### PR DESCRIPTION
## Summary

- The **espace** application card in the "Des applications reliées entre elles" section of the home page is now a clickable `<a>` link pointing to `https://espace.lychen.org` (opens in a new tab with `rel="noopener noreferrer"`).
- An `↗` icon (`IconArrowUpRight`) is displayed next to the state badge to signal the card is an external link.
- A `url?: string` field has been added to the `APPLICATIONS` constants and the `TranslatedApplication` type so future applications can get a link by simply adding a `url` entry — no template changes required.

## Files changed

- `libs/vue/applications/constants/Applications.ts` — added `url` field to the record type and set `url: 'https://espace.lychen.org'` for espace.
- `libs/vue/applications/composables/useApplicationsCatalog.ts` — expose `url` on `TranslatedApplication`.
- `projects/website/src/views/home/PageHomeUseCases.vue` — render cards as `<a>` when `application.url` is set, show `↗` icon.

## Test plan

- [ ] Visit the home page and scroll to the "Des applications reliées entre elles" section.
- [ ] Verify the espace card displays the `↗` icon next to its state badge.
- [ ] Click the espace card and confirm it opens `https://espace.lychen.org` in a new tab.
- [ ] Confirm other application cards (tera, myko, …) are not clickable and show no icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)