### PR TITLE
feat(website): redesign ODD section as bento grid layout

### DIFF
--- a/projects/website/src/views/home/PageHomeODD.vue
+++ b/projects/website/src/views/home/PageHomeODD.vue
@@ -29,20 +29,20 @@
       <div class="grid grid-cols-1 gap-4 md:grid-cols-[1fr_1.4fr]">
         <OddBentoCard
           :goal="two"
-          :image="images[2]"
+          :image="Goal2Url"
           :link-title="t('goals.link_title.2')"
           large
           class="min-h-80 md:col-start-2 md:row-span-2 md:row-start-1"
         />
         <OddBentoCard
           :goal="eleven"
-          :image="images[11]"
+          :image="Goal11Url"
           :link-title="t('goals.link_title.11')"
           class="min-h-56 md:col-start-1 md:row-start-1"
         />
         <OddBentoCard
           :goal="twelve"
-          :image="images[12]"
+          :image="Goal12Url"
           :link-title="t('goals.link_title.12')"
           class="min-h-56 md:col-start-1 md:row-start-2"
         />
@@ -76,12 +76,6 @@ const Container = defineAsyncComponent(
 const { t } = usePrefixedI18n(CONFIG);
 
 const { two, eleven, twelve } = useSustainableDevelopmentGoals();
-
-const images: { [key: number]: string } = {
-  2: Goal2Url,
-  11: Goal11Url,
-  12: Goal12Url,
-};
 
 const headerRef = ref<HTMLElement | null>(null);
 const headerVisible = ref(false);

--- a/projects/website/src/views/home/PageHomeODD.vue
+++ b/projects/website/src/views/home/PageHomeODD.vue
@@ -25,43 +25,27 @@
         >
       </div>
 
-      <div
-        class="flex w-full flex-col-reverse gap-10 md:grid md:grid-cols-[34%_1fr] md:items-center"
-      >
-        <div class="flex flex-col justify-center gap-8">
-          <GoalSubSection
-            v-for="goal in goals"
-            :key="goal.index"
-            :title="goal.title"
-            :description="goal.description"
-            :link="{
-              title: t(`goals.link_title.${goal.index}`),
-              href: goal.link,
-            }"
-            :expanded="goal.index === selectedGoal.index"
-            @click="selectedGoal = goal"
-          />
-        </div>
-        <figure
-          class="ring-on-surface/10 relative mx-auto overflow-hidden rounded-3xl shadow-xl ring-1"
-        >
-          <img
-            v-if="selectedGoal"
-            :src="`/sustainable-development-goals/icons/${selectedGoal.icon}`"
-            class="odd-icon absolute z-10 h-14 rounded-2xl shadow-lg md:h-20"
-            :alt="`Icône de l'objectif de développement durable n° ${selectedGoal.index}`"
-          />
-          <img
-            :key="selectedGoal.index"
-            :src="images[selectedGoal.index]"
-            :alt="`Image de l'objectif de développement durable n° ${selectedGoal.index}`"
-            class="motion-preset-slide-left-sm size-full object-cover"
-          />
-          <div
-            aria-hidden="true"
-            class="odd-photo-grade absolute inset-0"
-          />
-        </figure>
+      <!-- Bento grid: large "Faim zéro" card on the right, two smaller cards on the left -->
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-[1fr_1.4fr]">
+        <OddBentoCard
+          :goal="two"
+          :image="images[2]"
+          :link-title="t('goals.link_title.2')"
+          large
+          class="min-h-80 md:col-start-2 md:row-span-2 md:row-start-1"
+        />
+        <OddBentoCard
+          :goal="eleven"
+          :image="images[11]"
+          :link-title="t('goals.link_title.11')"
+          class="min-h-56 md:col-start-1 md:row-start-1"
+        />
+        <OddBentoCard
+          :goal="twelve"
+          :image="images[12]"
+          :link-title="t('goals.link_title.12')"
+          class="min-h-56 md:col-start-1 md:row-start-2"
+        />
       </div>
     </Container>
   </section>
@@ -71,15 +55,13 @@
 import Goal2Url from './assets/goal-2.webp';
 import Goal12Url from './assets/goal-12.webp';
 import Goal11Url from './assets/goal-11.webp';
-import { computed, defineAsyncComponent, ref } from 'vue';
+import { defineAsyncComponent, ref } from 'vue';
 import { useIntersectionObserver } from '@vueuse/core';
 import { useSustainableDevelopmentGoals } from '@lychen/vue-sustainable-development-goals/composables/useSustainableDevelopmentGoals';
 import { CONFIG } from './i18n';
 import { usePrefixedI18n } from '@lychen/vue-i18n/composables/useI18nExtended';
 
-const GoalSubSection = defineAsyncComponent(
-  () => import('@/views/home/component/GoalSubSection.vue'),
-);
+const OddBentoCard = defineAsyncComponent(() => import('@/views/home/component/OddBentoCard.vue'));
 
 const Title = defineAsyncComponent(() => import('@lychen/vue-components-website/title/Title.vue'));
 
@@ -94,9 +76,6 @@ const Container = defineAsyncComponent(
 const { t } = usePrefixedI18n(CONFIG);
 
 const { two, eleven, twelve } = useSustainableDevelopmentGoals();
-
-const goals = computed(() => [eleven.value, two.value, twelve.value]);
-const selectedGoal = ref(eleven.value);
 
 const images: { [key: number]: string } = {
   2: Goal2Url,
@@ -127,15 +106,6 @@ useIntersectionObserver(
   z-index: 0;
   background: var(--color-tertiary);
   opacity: 0.1;
-}
-
-.odd-icon {
-  top: -20px;
-  left: -20px;
-}
-
-.odd-photo-grade {
-  background: linear-gradient(180deg, transparent 55%, rgb(0 0 0 / 0.18) 100%);
 }
 
 .reveal-group > * {

--- a/projects/website/src/views/home/component/OddBentoCard.vue
+++ b/projects/website/src/views/home/component/OddBentoCard.vue
@@ -1,0 +1,63 @@
+<template>
+  <article class="bento-card group relative overflow-hidden rounded-3xl shadow-lg">
+    <img
+      :src="image"
+      :alt="goal.title"
+      class="size-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
+    />
+    <img
+      :src="`/sustainable-development-goals/icons/${goal.icon}`"
+      class="absolute top-4 left-4 h-10 rounded-xl shadow-md ring-2 ring-white/20 md:h-12"
+      :alt="`ODD n°${goal.index}`"
+    />
+    <div class="bento-overlay absolute inset-0" />
+    <div class="absolute right-0 bottom-0 left-0 flex flex-col gap-2 p-5 text-white">
+      <h3
+        class="font-lexend leading-tight font-bold"
+        :class="large ? 'text-2xl md:text-3xl' : 'text-lg md:text-xl'"
+      >
+        {{ goal.title }}
+      </h3>
+      <p
+        v-if="large"
+        class="line-clamp-3 text-sm leading-relaxed opacity-80 md:text-base"
+      >
+        {{ goal.description }}
+      </p>
+      <a
+        :href="goal.link"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="mt-0.5 inline-flex items-center gap-1.5 text-sm font-semibold opacity-90 hover:opacity-100"
+      >
+        <span class="underline underline-offset-2">{{ linkTitle }}</span>
+        <IconArrowUpRight class="h-4 w-4 shrink-0" />
+      </a>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+import IconArrowUpRight from '@lychen/vue-icons/IconArrowUpRight.vue';
+import type { SustainableDevelopmentGoal } from '@lychen/vue-sustainable-development-goals/model/SustainableDevelopmentGoal';
+
+interface Props {
+  goal: SustainableDevelopmentGoal;
+  image: string;
+  linkTitle: string;
+  large?: boolean;
+}
+
+defineProps<Props>();
+</script>
+
+<style scoped>
+.bento-overlay {
+  background: linear-gradient(
+    to top,
+    rgb(0 0 0 / 0.72) 0%,
+    rgb(0 0 0 / 0.05) 55%,
+    transparent 100%
+  );
+}
+</style>


### PR DESCRIPTION
## Summary

- Replaces the accordion-style SDG section (text list + single rotating photo) with a static bento card grid
- Two smaller cards on the left (ODD 11 — Villes durables, ODD 12 — Consommation responsable) and a larger card on the right (ODD 2 — Faim zéro) spanning both rows
- Each card shows a full-bleed photo with the SDG icon badge, gradient overlay, title, and link; the large card additionally surfaces the full description text
- On mobile, the large "Faim zéro" card appears first, followed by the two smaller ones

## New component

`OddBentoCard.vue` — replaces `GoalSubSection.vue` in this section. Accepts `goal`, `image`, `linkTitle`, and an optional `large` flag.

## Test plan

- [ ] Desktop: verify bento grid renders with 2 small cards left + 1 large card right
- [ ] Large card (Faim zéro) spans the full height of both small cards
- [ ] Mobile: large card appears first, small cards stack below
- [ ] SDG icon badge visible in top-left of each card
- [ ] Hover scale animation works on all cards
- [ ] External links open in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)