### PR TITLE
fix(i18n): align fr-FR/en-US locale keys to clear intlify warnings

### DIFF
--- a/libs/i18n/tera/land-role/en-US.ts
+++ b/libs/i18n/tera/land-role/en-US.ts
@@ -7,6 +7,9 @@ export default {
     permissions: {
       label: 'Permissions',
     },
+    land_members: {
+      default: 'no member | {count} member | {count} members',
+    },
   },
   action: {
     create: {

--- a/libs/vue/applications/i18n/fr-FR.json
+++ b/libs/vue/applications/i18n/fr-FR.json
@@ -9,6 +9,10 @@
     "name": "tera",
     "description": "Facilite la gestion des cultures et connecte citoyens et maraîchers à des espaces partagés"
   },
+  "website": {
+    "name": "website",
+    "description": "Le site web principal du projet Lychen"
+  },
   "myko": {
     "name": "myko",
     "description": "Optimise la culture de champignons et sensibilise à la mycologie"

--- a/libs/vue/tera/components/land-task/badges/state/i18n/en-US.ts
+++ b/libs/vue/tera/components/land-task/badges/state/i18n/en-US.ts
@@ -1,1 +1,7 @@
-export default {};
+import { LandTaskJsonldState as State } from '@lychen/typescript-tera-api-sdk/generated/tera-api';
+
+export default {
+  [State.to_be_done]: 'to be done',
+  [State.in_progress]: 'in progress',
+  [State.done]: 'done',
+};

--- a/projects/robust/website/src/pages/home/i18n/en-US.ts
+++ b/projects/robust/website/src/pages/home/i18n/en-US.ts
@@ -66,7 +66,7 @@ export default {
     description:
       'Whether you are an individual, an association, a business, or a local authority, Robust adapts to all to build a strong and fulfilling local future together.',
     citizen: 'Citizens',
-    association: 'Associations',
+    associations: 'Associations',
     companies: 'Businesses',
     cities: 'Communities',
   },

--- a/projects/tera/app/src/components/banners/i18n/en-US.ts
+++ b/projects/tera/app/src/components/banners/i18n/en-US.ts
@@ -1,1 +1,7 @@
-export default {};
+export default {
+  heading: 'Share your land',
+  description:
+    'You can share your land with someone from the community. This helps your local ecosystem grow and strengthen.',
+  searchCount: '{count} people are looking for land',
+  share: 'Post a listing',
+};

--- a/projects/tera/app/src/pages/herbarium/i18n/en-US.ts
+++ b/projects/tera/app/src/pages/herbarium/i18n/en-US.ts
@@ -1,3 +1,18 @@
 export default {
   title: 'Herbarium',
+  global: {
+    title: 'Global herbarium',
+    description:
+      'A collaborative directory bringing together detailed records of every plant, contributed by the community.',
+  },
+  custom: {
+    title: 'Personal herbarium',
+    description:
+      'Your private plant collection, with records you create and customize based on your observations.',
+  },
+  banner: {
+    title: "Let's build a global herbarium together, enriched by everyone's contributions!",
+    description:
+      'The goal is to create a global herbarium made by users. You are free to create your own plant records, and ideally submit them to the global database. A single shared herbarium lets us consolidate accurate data that scientists can analyze.',
+  },
 };

--- a/projects/website/src/views/team/i18n/fr-FR.json
+++ b/projects/website/src/views/team/i18n/fr-FR.json
@@ -5,7 +5,8 @@
   },
   "team_section": {
     "title": "L'équipe Lychen",
-    "description": "Nous sommes une équipe dédiée à la création d'un écosystème numérique open-source. Notre mission : connecter citoyens, producteurs, associations et collectivités pour favoriser une agriculture durable et la protection de la biodiversité."
+    "description": "Nous sommes une équipe dédiée à la création d'un écosystème numérique open-source. Notre mission : connecter citoyens, producteurs, associations et collectivités pour favoriser une agriculture durable et la protection de la biodiversité.",
+    "cta": "Notre charte"
   },
   "contact_label": "N'hésitez pas à nous contacter",
   "ecosystem_section": {


### PR DESCRIPTION
## What

Several i18n locale files had keys present in one language but missing in its counterpart. Because `fr-FR` is configured as **both** the default and the fallback locale ([`libs/vue/i18n/configs/Default.ts`](https://github.com/lychen-lab/lychen/blob/main/libs/vue/i18n/configs/Default.ts)), every gap surfaced an `@intlify` *"Not found 'X' key in 'Y' locale messages"* warning at runtime.

## How

Audited **all 80 i18n directories** (`.ts` and `.json` pairs) for leaf-key parity by loading each pair and diffing the full set of leaf-key paths. Found 17 mismatched keys across 7 files — now back to **0 mismatches**.

| File | Problem | Fix |
|------|---------|-----|
| `libs/vue/tera/components/land-task/badges/state/i18n/en-US.ts` | `export default {}` — all 3 task-state labels missing | Added enum-keyed `to be done / in progress / done` |
| `projects/tera/app/src/components/banners/i18n/en-US.ts` | `export default {}` — 4 keys missing | Translated `heading/description/searchCount/share` |
| `projects/tera/app/src/pages/herbarium/i18n/en-US.ts` | only `title` — 6 keys missing | Added `global/custom/banner` blocks |
| `libs/i18n/tera/land-role/en-US.ts` | `property.land_members.default` missing | Added EN plural form |
| `libs/vue/applications/i18n/fr-FR.json` | whole `website` entry missing | Added `name` + FR `description` |
| `projects/website/src/views/team/i18n/fr-FR.json` | `team_section.cta` missing | Added `"Notre charte"` |
| `projects/robust/website/src/pages/home/i18n/en-US.ts` | key typo `association` vs `associations` | Renamed to `associations` |

The last one was a genuine bug, not just a parity gap: `PageHomePeople.vue` calls `t('people.associations')`, so the English label was silently falling back.

## Notes

- Intentionally-empty locale pairs (espace views, onboarding, etc.) that are empty in **both** locales were left as-is — they're consistent and don't warn.
- All changed files pass Prettier; pre-commit `format-fix` + `lint-fix` ran clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)