### PR TITLE
fix(api): restore tera-api api-key denormalization (Symfony 8 Serializer attributes)

### DIFF
--- a/projects/tera/api/src/Dto/LandMemberInvitationCheckEmailUnicityDto.php
+++ b/projects/tera/api/src/Dto/LandMemberInvitationCheckEmailUnicityDto.php
@@ -2,7 +2,7 @@
 
 namespace App\Dto;
 
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 class LandMemberInvitationCheckEmailUnicityDto
 {

--- a/projects/tera/api/src/Entity/LandApiKey.php
+++ b/projects/tera/api/src/Entity/LandApiKey.php
@@ -22,7 +22,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Lychen\UtilModel\Abstract\AbstractIdOrmAndUlidApiIdentified;
 use Lychen\UtilModel\Trait\CreatedAtTrait;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Validator\Constraints as Assert;
 

--- a/projects/tera/api/src/Entity/PersonApiKey.php
+++ b/projects/tera/api/src/Entity/PersonApiKey.php
@@ -19,7 +19,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Lychen\UtilModel\Abstract\AbstractIdOrmAndUlidApiIdentified;
 use Lychen\UtilModel\Trait\CreatedAtTrait;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Validator\Constraints as Assert;
 

--- a/projects/tera/api/src/Security/Service/PermissionHolderRetriever.php
+++ b/projects/tera/api/src/Security/Service/PermissionHolderRetriever.php
@@ -10,7 +10,7 @@ use App\Repository\LandMemberRepository;
 use App\Security\Constant\PersonPermission;
 use App\Security\Interface\LandAwareInterface;
 use App\Security\Interface\PermissionHolder;
-use PHPUnit\Framework\Exception;
+use Exception;
 use Symfony\Bundle\SecurityBundle\Security;
 
 readonly class PermissionHolderRetriever
@@ -29,8 +29,9 @@ readonly class PermissionHolderRetriever
                 return $currentUser;
             }
             try {
-                if ($currentUser instanceof Person) {
-                    return $this->getLandMember($context->subject->getLand(), $currentUser);
+                $land = $context->subject->getLand();
+                if ($currentUser instanceof Person && null !== $land) {
+                    return $this->getLandMember($land, $currentUser);
                 }
             } catch (Exception $exception) {
 

--- a/projects/tera/api/tests/Security/LandMemberInvitationSecurityTest.php
+++ b/projects/tera/api/tests/Security/LandMemberInvitationSecurityTest.php
@@ -231,6 +231,7 @@ class LandMemberInvitationSecurityTest extends AbstractApiTestCase
                     ]])
             ->assertStatus(403);
 
+        // User cannot check email unicity for a Land for which they do not have permission
         $landRole = $this->createLandRole($context1->land);
         $this->addLandMember($context1, [$landRole]);
         $this->browser()->actingAs($context1->landMembers[0]->getPerson())
@@ -240,7 +241,7 @@ class LandMemberInvitationSecurityTest extends AbstractApiTestCase
                         'email' => $email,
                         'land' => $context1->land->getUlid()->toString()
                     ]])
-            ->assertStatus(401);
+            ->assertStatus(403);
     }
 
     public function testCollectionByEmail()


### PR DESCRIPTION
## What & why

Follow-up to the Symfony 8.1 / PHP 8.5 migration ([#146](https://github.com/lychen-lab/lychen/pull/146)). That migration left **3 failing PHPUnit tests** in `tera-api`. This PR fixes the underlying bugs and brings the `tera-api` **Functional + Security** suites fully green.

## Root cause

Symfony 8 removed the legacy `Symfony\Component\Serializer\Annotation\*` attribute aliases (only `Serializer\Attribute\*` remains). Three classes still imported the now-nonexistent `Annotation\Groups`:

- `src/Entity/PersonApiKey.php`
- `src/Entity/LandApiKey.php`
- `src/Dto/LandMemberInvitationCheckEmailUnicityDto.php`

The serializer's `AttributeLoader` **silently skips unknown attributes** (`isKnownAttribute()` only matches `Attribute\*`), so every `#[Groups(...)]` on these classes was dropped. With no serialization groups, the API-key POST bodies were never denormalized — `name`, `land`, and `permissions` all arrived `null`:

- `PersonApiKey` → NOT-NULL violation on `name` → **500**
- `LandApiKey` → null `land` reached `PermissionHolderRetriever::getLandMember(Land $land, …)` → **TypeError** → **500**

## Changes

- **Serializer imports** — switch the three files to `Serializer\Attribute\Groups`, restoring their groups so POST bodies denormalize again.
- **`PermissionHolderRetriever`** (latent prod bug surfaced by the above):
  - Replace the test-only `PHPUnit\Framework\Exception` (fatal if thrown in prod) with the global `\Exception`.
  - Null-guard `getLand()` before calling `getLandMember(Land $land, …)` so a missing land can never trigger a `TypeError`.
- **`LandMemberInvitationSecurityTest::testCheckUnicity`** — correct a stale expectation: an *authenticated* member lacking the permission gets **403**, not **401** (consistent with every sibling case in the file). No production authorization logic was changed.

## Verification

Ran the full `tera-api` Functional + Security suites per-file (Docker, FrankenPHP/PHP 8.5 test image): **45/45 files pass, 0 failures.** The previously-passing `LandMemberInvitationTest::testCheckUnicity` (which asserts the `isUnique` body) still passes after the DTO import fix.

## Out of scope

Re-enabling `lint-php` / `phpstan` (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
