### PR TITLE
feat(infra): self-hosted Supabase as PostgreSQL provider

### DIFF
--- a/projects/common/supabase/.env.example
+++ b/projects/common/supabase/.env.example
@@ -1,0 +1,44 @@
+# Supabase (self-hosted) — PostgreSQL provider for the Lychen APIs.
+#
+# Local: copy to `.env` only if you want to run this stack for parity; the
+#        committed defaults are local-safe, so `moon common-supabase:up` works
+#        without any .env at all.
+# VPS:   set EVERY secret below to a strong, unique value in Dokploy's env.
+#        Do NOT commit a real .env (it is gitignored).
+
+# ── Superuser ────────────────────────────────────────────────────────────────
+POSTGRES_DB=postgres
+POSTGRES_PASSWORD=PasswordForLocal!
+
+# Used by the supabase/postgres init scripts. Min 32 chars. Regenerate per env:
+#   openssl rand -base64 48
+JWT_SECRET=super-secret-jwt-token-with-at-least-32-chars-change-me
+JWT_EXP=3600
+
+# ── Per-application databases & owner roles ──────────────────────────────────
+# init/01-app-databases.sh creates database `<app>` owned by `<app>_app`.
+# Each API connects only to its own database with its own credentials.
+TERA_DB_USER=tera_app
+TERA_DB_PASSWORD=PasswordForLocal!
+ESPACE_DB_USER=espace_app
+ESPACE_DB_PASSWORD=PasswordForLocal!
+FLORA_DB_USER=flora_app
+FLORA_DB_PASSWORD=PasswordForLocal!
+
+# ── Host port bindings (loopback only) ───────────────────────────────────────
+SUPABASE_DB_PORT=54322
+SUPABASE_STUDIO_PORT=54323
+
+# ── Network ──────────────────────────────────────────────────────────────────
+# Local default is the external `lychen-network`. On the VPS, point this at the
+# shared Dokploy network that the API services are also attached to.
+SUPABASE_NETWORK=lychen-network
+
+# ── Studio dashboard (optional `studio` profile only) ────────────────────────
+STUDIO_DEFAULT_ORGANIZATION=Lychen
+STUDIO_DEFAULT_PROJECT=Lychen
+# Only required for Studio's API/Auth/Storage panels. Generate JWTs signed with
+# JWT_SECRET (https://supabase.com/docs/guides/self-hosting/docker#api-keys).
+# Leave blank to use just the Table/SQL editors.
+ANON_KEY=
+SERVICE_ROLE_KEY=

--- a/projects/common/supabase/.gitignore
+++ b/projects/common/supabase/.gitignore
@@ -1,0 +1,4 @@
+# Never commit real secrets; `.env.example` is the tracked template.
+.env
+.env.*
+!.env.example

--- a/projects/common/supabase/README.md
+++ b/projects/common/supabase/README.md
@@ -1,0 +1,147 @@
+# Supabase — self-hosted PostgreSQL provider
+
+This stack runs **Supabase Postgres** as the database engine for the Lychen APIs
+(`tera`, `espace`, `flora`). It is the first half of the Supabase integration.
+
+**Scope of this integration (intentionally narrow):**
+
+| Concern | Decision |
+| --- | --- |
+| Database engine | **Supabase Postgres** (this stack) — local optional, staging/prod on the VPS |
+| Authentication | **Unchanged — stays on Zitadel.** GoTrue/PostgREST/Realtime are not run |
+| File storage / buckets | **Deferred to a follow-up PR** (Supabase Storage / S3) |
+| App ↔ DB access | Symfony **Doctrine** over a privileged role — not PostgREST, not the anon key |
+
+Because the apps talk to Postgres through Doctrine exactly as before, **no
+application code changes** are required — only the `DATABASE_URL` each API
+receives per environment.
+
+## What runs here
+
+| Service | Image | Default? | Purpose |
+| --- | --- | --- | --- |
+| `supabase-db` | `supabase/postgres:15.8.1.085` | **yes** | The Postgres engine (Postgres 15) |
+| `supabase-meta` | `supabase/postgres-meta:v0.96.6` | no (`studio` profile) | Backs the Studio table/SQL editors |
+| `supabase-studio` | `supabase/studio:2026.06.03-sha-0bca601` | no (`studio` profile) | Optional admin dashboard, **loopback-only** |
+
+`init/01-app-databases.sh` runs once on first boot and creates one database +
+owner role per app: `tera`/`tera_app`, `espace`/`espace_app`, `flora`/`flora_app`.
+One Postgres instance, three isolated databases — mirroring local, where each API
+has its own database today.
+
+## Environment topology
+
+| Environment | Where Postgres lives | Notes |
+| --- | --- | --- |
+| **Local / CI** | The existing per-API `*-database` containers (`postgres:16-alpine`) | **Unchanged.** This stack is optional locally (parity + Studio) |
+| **Staging** | This stack on the VPS (Dokploy) | One instance, databases `tera`/`espace`/`flora` |
+| **Production** | A separate instance of this stack on the VPS (Dokploy) | Isolated from staging; own volume, own secrets |
+
+> CI deliberately keeps its throwaway Postgres container: the test suite relies on
+> per-worker database suffixing (`dbname_suffix: _test%env(TEST_TOKEN)%`), which a
+> shared remote database cannot provide. Do not point CI at Supabase.
+
+## Local use (optional)
+
+The committed defaults are local-safe, so no `.env` is needed:
+
+```bash
+moon common-supabase:up                       # just the database
+docker compose --profile studio up -d         # database + Studio on http://127.0.0.1:54323
+moon common-supabase:down
+```
+
+The database is reachable from host DB clients at `127.0.0.1:54322` and from other
+containers on `lychen-network` as `supabase-db`. To run an API against it instead
+of its own container, override `DATABASE_URL` in that project's `.env.local`:
+
+```dotenv
+DATABASE_URL=postgresql://tera_app:PasswordForLocal!@supabase-db:5432/tera?serverVersion=15&charset=utf8
+```
+
+## Staging / production on the VPS (Dokploy)
+
+1. **Create a shared network** once on the VPS so the API containers can reach the
+   database by name:
+
+   ```bash
+   docker network create lychen-data
+   ```
+
+2. **Deploy this folder as a Dokploy “Compose” service.** In its environment, set
+   strong, unique values for every secret in [`.env.example`](./.env.example) and:
+
+   ```dotenv
+   SUPABASE_NETWORK=lychen-data
+   ```
+
+   Leave the `studio` profile **off** in production (see Security).
+
+3. **Attach each API service to `lychen-data`** in Dokploy (Advanced → Networks).
+   No change to the APIs' `compose.prod.yml` is required.
+
+4. **Point each API at its database** by setting `DATABASE_URL` in that API's
+   Dokploy environment (see matrix below), then redeploy.
+
+5. **Run migrations** against the new database, once, from the deployed API
+   container:
+
+   ```bash
+   php bin/console doctrine:migrations:migrate --no-interaction
+   ```
+
+### `DATABASE_URL` matrix
+
+`serverVersion=15` matches `supabase/postgres` (Postgres 15) — set it correctly so
+Doctrine selects the right platform.
+
+| API | Local (unchanged) | Staging / production (Supabase) |
+| --- | --- | --- |
+| tera | `postgresql://userlocal:PasswordForLocal!@tera-database:5432/app?serverVersion=16&charset=utf8` | `postgresql://tera_app:<TERA_DB_PASSWORD>@supabase-db:5432/tera?serverVersion=15&charset=utf8` |
+| espace | `…@espace-database:5432/app?serverVersion=16…` | `postgresql://espace_app:<ESPACE_DB_PASSWORD>@supabase-db:5432/espace?serverVersion=15&charset=utf8` |
+| flora | `…@flora-database:5432/app?serverVersion=16…` | `postgresql://flora_app:<FLORA_DB_PASSWORD>@supabase-db:5432/flora?serverVersion=15&charset=utf8` |
+
+Host `supabase-db` resolves over the shared `lychen-data` network. If you connect
+across hosts instead, expose the port and append `&sslmode=require`.
+
+## Security
+
+- **Database**: bound to `127.0.0.1` on the host and reachable only over the
+  internal Docker network. Never publish it to a public interface; rely on the
+  shared network + the VPS firewall.
+- **Studio**: the trimmed stack has **no auth gateway (Kong)**, so Studio is
+  unauthenticated. It is bound to loopback and the `studio` profile is **off by
+  default**. For VPS admin, reach it through an SSH tunnel
+  (`ssh -L 54323:127.0.0.1:54323 vps`) rather than exposing it.
+- **Secrets**: every password and `JWT_SECRET` in `.env.example` is a local
+  placeholder. Generate fresh values per environment (`openssl rand -base64 48`)
+  and store them only in Dokploy. Never commit a real `.env`.
+- **Least privilege**: each API gets a role that owns only its own database, so a
+  leaked credential cannot reach another app's data.
+
+## Backups
+
+[`scripts/backup.sh`](./scripts/backup.sh) dumps all three databases to
+timestamped, gzipped files. Run it from the stack directory on the VPS and wire it
+to cron:
+
+```cron
+0 3 * * * cd /path/to/supabase && BACKUP_DIR=/var/backups/supabase ./scripts/backup.sh
+```
+
+Also snapshot the `supabase_db_data` volume (or the VPS disk) for point-in-time
+recovery, and copy dumps off-box.
+
+## Notes & future work
+
+- **Connection limits**: each FrankenPHP worker holds a connection. With three
+  APIs sharing one instance, watch `max_connections`. If you approach the limit,
+  add the Supabase **Supavisor** pooler (transaction mode on `6543`) and disable
+  server-side prepared statements in the pooled DSN; keep migrations on the direct
+  `5432` connection.
+- **Version parity**: local is Postgres 16, this stack is Postgres 15. The current
+  schema uses no version-specific features, so this is safe; for strict parity,
+  pin the local containers to `supabase/postgres` too.
+- **Not included** (kept off on purpose): GoTrue auth, PostgREST, Realtime,
+  Storage, Edge Functions, Kong. Auth remains Zitadel; Storage arrives in the
+  follow-up PR.

--- a/projects/common/supabase/compose.yml
+++ b/projects/common/supabase/compose.yml
@@ -1,0 +1,91 @@
+name: supabase
+
+# Self-hosted Supabase, scoped to its role as the PostgreSQL provider for the
+# Lychen APIs (tera / espace / flora). Auth stays on Zitadel and Storage is a
+# follow-up; this stack therefore runs ONLY the database engine by default.
+#
+# - `supabase-db` is the genuine Supabase Postgres image (extensions + tuning).
+# - `supabase-studio` + `supabase-meta` are an OPTIONAL dashboard, gated behind
+#   the `studio` compose profile and bound to localhost (see README for why).
+#
+# Local (optional, for parity): `moon common-supabase:up`
+# With dashboard:                `docker compose --profile studio up -d`
+# Staging / production:          deployed on the VPS via Dokploy (see README).
+
+services:
+  supabase-db:
+    image: supabase/postgres:15.8.1.085
+    restart: unless-stopped
+    environment:
+      POSTGRES_HOST: /var/run/postgresql
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      POSTGRES_PORT: 5432
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-PasswordForLocal!}
+      # Consumed by the supabase/postgres first-boot init scripts:
+      JWT_SECRET: ${JWT_SECRET:-super-secret-jwt-token-with-at-least-32-chars-change-me}
+      JWT_EXP: ${JWT_EXP:-3600}
+      # Consumed by init/01-app-databases.sh to create one database + owner role
+      # per application. OVERRIDE every password in staging/production.
+      TERA_DB_USER: ${TERA_DB_USER:-tera_app}
+      TERA_DB_PASSWORD: ${TERA_DB_PASSWORD:-PasswordForLocal!}
+      ESPACE_DB_USER: ${ESPACE_DB_USER:-espace_app}
+      ESPACE_DB_PASSWORD: ${ESPACE_DB_PASSWORD:-PasswordForLocal!}
+      FLORA_DB_USER: ${FLORA_DB_USER:-flora_app}
+      FLORA_DB_PASSWORD: ${FLORA_DB_PASSWORD:-PasswordForLocal!}
+    volumes:
+      - supabase_db_data:/var/lib/postgresql/data:rw
+      - ./init/01-app-databases.sh:/docker-entrypoint-initdb.d/01-app-databases.sh:ro
+    ports:
+      # Bound to loopback: reachable by desktop DB clients on the host, never
+      # exposed publicly. App containers reach it in-network as `supabase-db`.
+      - '127.0.0.1:${SUPABASE_DB_PORT:-54322}:5432'
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-U', 'postgres', '-h', 'localhost']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  supabase-meta:
+    image: supabase/postgres-meta:v0.96.6
+    profiles: [studio]
+    restart: unless-stopped
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+    environment:
+      PG_META_PORT: 8080
+      PG_META_DB_HOST: supabase-db
+      PG_META_DB_PORT: 5432
+      PG_META_DB_NAME: ${POSTGRES_DB:-postgres}
+      PG_META_DB_USER: supabase_admin
+      PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD:-PasswordForLocal!}
+
+  supabase-studio:
+    image: supabase/studio:2026.06.03-sha-0bca601
+    profiles: [studio]
+    restart: unless-stopped
+    depends_on:
+      - supabase-meta
+    environment:
+      STUDIO_PG_META_URL: http://supabase-meta:8080
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-PasswordForLocal!}
+      DEFAULT_ORGANIZATION_NAME: ${STUDIO_DEFAULT_ORGANIZATION:-Lychen}
+      DEFAULT_PROJECT_NAME: ${STUDIO_DEFAULT_PROJECT:-Lychen}
+      AUTH_JWT_SECRET: ${JWT_SECRET:-super-secret-jwt-token-with-at-least-32-chars-change-me}
+      # Only needed for Studio's API/Auth/Storage panels (not run here); the
+      # Table & SQL editors work through postgres-meta without them.
+      SUPABASE_ANON_KEY: ${ANON_KEY:-}
+      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY:-}
+    ports:
+      - '127.0.0.1:${SUPABASE_STUDIO_PORT:-54323}:3000'
+
+volumes:
+  supabase_db_data:
+
+networks:
+  # Local: the external `lychen-network` created by `common-network:create-network`.
+  # VPS:   set SUPABASE_NETWORK to the shared Dokploy network the APIs also join.
+  default:
+    name: ${SUPABASE_NETWORK:-lychen-network}
+    external: true

--- a/projects/common/supabase/init/01-app-databases.sh
+++ b/projects/common/supabase/init/01-app-databases.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Creates one PostgreSQL database + owner role per Lychen application.
+#
+# Runs automatically on FIRST cluster initialization (empty data volume) via the
+# postgres docker-entrypoint, which executes files in /docker-entrypoint-initdb.d
+# against a temporary local server as the `postgres` superuser.
+#
+# Every step is idempotent, so it is also safe to run by hand later, e.g.:
+#   docker compose exec -e TERA_DB_PASSWORD=... supabase-db \
+#     bash /docker-entrypoint-initdb.d/01-app-databases.sh
+set -euo pipefail
+
+superuser="${POSTGRES_USER:-postgres}"
+superdb="${POSTGRES_DB:-postgres}"
+
+create_app_db() {
+  local db="$1" role="$2" password="$3"
+
+  if [ -z "${password}" ]; then
+    echo "WARN: no password for role '${role}', skipping database '${db}'" >&2
+    return 0
+  fi
+
+  # Role + database. psql variable substitution (:'x' / :"x") keeps identifiers
+  # and the password safely quoted; CREATE ROLE/DATABASE are guarded with \gexec
+  # so re-runs are no-ops. The heredoc is quoted so the shell never expands $.
+  PGPASSWORD="${POSTGRES_PASSWORD:-}" psql -v ON_ERROR_STOP=1 \
+    --username "${superuser}" --dbname "${superdb}" \
+    -v db="${db}" -v role="${role}" -v pwd="${password}" <<'EOSQL'
+SELECT format('CREATE ROLE %I LOGIN PASSWORD %L', :'role', :'pwd')
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = :'role')\gexec
+SELECT format('CREATE DATABASE %I OWNER %I', :'db', :'role')
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = :'db')\gexec
+EOSQL
+
+  # Schema ownership so Doctrine migrations can run DDL. Since PG15 the `public`
+  # schema is not world-writable by default, so the app role must own it.
+  PGPASSWORD="${POSTGRES_PASSWORD:-}" psql -v ON_ERROR_STOP=1 \
+    --username "${superuser}" --dbname "${db}" \
+    -v db="${db}" -v role="${role}" <<'EOSQL'
+GRANT ALL PRIVILEGES ON DATABASE :"db" TO :"role";
+ALTER SCHEMA public OWNER TO :"role";
+GRANT ALL ON SCHEMA public TO :"role";
+EOSQL
+
+  echo "OK: database '${db}' owned by role '${role}'"
+}
+
+create_app_db "tera"   "${TERA_DB_USER:-tera_app}"     "${TERA_DB_PASSWORD:-}"
+create_app_db "espace" "${ESPACE_DB_USER:-espace_app}" "${ESPACE_DB_PASSWORD:-}"
+create_app_db "flora"  "${FLORA_DB_USER:-flora_app}"   "${FLORA_DB_PASSWORD:-}"

--- a/projects/common/supabase/moon.yml
+++ b/projects/common/supabase/moon.yml
@@ -1,0 +1,6 @@
+id: common-supabase
+language: unknown
+layer: automation
+stack: backend
+tags:
+- compose

--- a/projects/common/supabase/scripts/backup.sh
+++ b/projects/common/supabase/scripts/backup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Dump every Lychen application database to a timestamped, gzipped file.
+#
+# Intended to run from this stack's directory on the VPS (cron-friendly):
+#   0 3 * * * cd /path/to/supabase && BACKUP_DIR=/var/backups/supabase ./scripts/backup.sh
+#
+# Env:
+#   BACKUP_DIR   destination directory (default: ./backups)
+#   DB_SERVICE   compose service name of the database (default: supabase-db)
+#   APP_DBS      space-separated database list (default: "tera espace flora")
+#   RETENTION    delete dumps older than N days (default: 14; 0 disables)
+set -euo pipefail
+
+backup_dir="${BACKUP_DIR:-./backups}"
+db_service="${DB_SERVICE:-supabase-db}"
+app_dbs="${APP_DBS:-tera espace flora}"
+retention="${RETENTION:-14}"
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+
+mkdir -p "${backup_dir}"
+
+for db in ${app_dbs}; do
+  out="${backup_dir}/${db}-${stamp}.sql.gz"
+  echo "Dumping '${db}' -> ${out}"
+  # pg_dump as the postgres superuser inside the db container; PGPASSWORD comes
+  # from the container's own POSTGRES_PASSWORD env.
+  docker compose exec -T "${db_service}" \
+    sh -c 'PGPASSWORD="$POSTGRES_PASSWORD" pg_dump -U postgres -d '"${db}"' --no-owner' \
+    | gzip > "${out}"
+done
+
+if [ "${retention}" -gt 0 ]; then
+  echo "Pruning dumps older than ${retention} day(s)"
+  find "${backup_dir}" -name '*.sql.gz' -type f -mtime "+${retention}" -delete
+fi
+
+echo "Done."


### PR DESCRIPTION
## What

Adds `projects/common/supabase/` — a self-hosted Supabase stack scoped to being the **PostgreSQL provider** for the `tera` / `espace` / `flora` APIs, intended to run on the VPS (via Dokploy) for **staging and production**.

This is the **PostgreSQL half** of the Supabase integration. **File storage / buckets are deliberately left for a follow-up PR.**

## Decisions baked in

| Concern | Decision |
| --- | --- |
| DB engine | **Supabase Postgres** (`supabase/postgres:15.8.1.085`) |
| Hosting (staging + prod) | **Self-hosted on the VPS**, deployed as a Dokploy Compose service |
| Local / CI | **Unchanged** — keep the per-API `*-database` containers (CI needs per-worker test-DB suffixing) |
| Auth | **Stays on Zitadel** — GoTrue / PostgREST / Realtime are not run |
| App ↔ DB | Symfony **Doctrine** over a per-app privileged role — not PostgREST / anon key |

Because the apps reach Postgres through Doctrine exactly as before, this PR is **purely additive — no application, compose, or env files were modified**, so it cannot affect current local/CI/staging behaviour. Activation is a deliberate Dokploy env change (the `DATABASE_URL` matrix is in the README).

## Contents

- **`compose.yml`** — `supabase-db` (the engine) by default; `supabase-meta` + `supabase-studio` behind an opt-in `studio` profile, bound to `127.0.0.1` (the trimmed stack ships no Kong, so Studio is unauthenticated → loopback/SSH-tunnel only).
- **`init/01-app-databases.sh`** — idempotent first-boot creation of one database + owner role per app (`tera`/`tera_app`, …), each owning its own `public` schema so Doctrine migrations can DDL on PG15.
- **`moon.yml`** — `common-supabase` project (`tags: [compose]`) → `moon common-supabase:up` / `:down`.
- **`README.md`** — env topology, `DATABASE_URL` matrix (incl. `serverVersion=15`), step-by-step Dokploy deploy + shared-network wiring, Studio security, backups, and connection-limit / Supavisor guidance.
- **`scripts/backup.sh`** — gzipped `pg_dump` of all three databases with retention, cron-ready.
- **`.env.example`** + **`.gitignore`** — local-safe placeholder secrets; real `.env` never committed.

## Activation (operational, when ready)

1. `docker network create lychen-data` on the VPS.
2. Deploy this folder as a Dokploy Compose service; set strong secrets + `SUPABASE_NETWORK=lychen-data`.
3. Attach each API service to `lychen-data` in Dokploy.
4. Set each API's `DATABASE_URL` (README matrix) and redeploy.
5. `php bin/console doctrine:migrations:migrate` once per app.

## Verification

- `docker compose config` passes for both the default and `--profile studio` renders.
- `bash -n` clean on both shell scripts; executable bits committed (`100755`).
- Not booted end-to-end in CI (requires the VPS network + secrets); first real boot is the Dokploy deploy above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)