### PR TITLE
fix(api): replace removed monolog "sentry" handler type with service handler

### DIFF
--- a/projects/espace/api/config/packages/sentry.php
+++ b/projects/espace/api/config/packages/sentry.php
@@ -2,21 +2,33 @@
 
 declare(strict_types=1);
 
+use Monolog\Logger;
+use Sentry\Monolog\Handler;
 use Sentry\State\HubInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
 return static function (ContainerConfigurator $containerConfigurator): void {
     if ($containerConfigurator->env() === 'prod') {
+        // monolog-bundle 4 removed the built-in "sentry" handler type. Register the
+        // Sentry handler as a service and wire it through a "service" handler instead.
+        // https://docs.sentry.io/platforms/php/guides/symfony/integrations/monolog/
+        $containerConfigurator->services()
+            ->set(Handler::class)
+            ->arg('$hub', service(HubInterface::class))
+            ->arg('$level', Logger::ERROR)
+            ->arg('$fillExtraContext', true);
+
         $containerConfigurator->extension('monolog', [
             'handlers' => [
                 'sentry' => [
-                    'fill_extra_context' => true,
-                    'hub_id' => HubInterface::class,
-                    'level' => Monolog\Logger::ERROR,
-                    'type' => 'sentry',
+                    'id' => Handler::class,
+                    'type' => 'service',
                 ],
             ],
         ]);
+
         $containerConfigurator->extension('sentry', [
             'dsn' => '%env(SENTRY_DSN)%',
             'register_error_handler' => false,

--- a/projects/flora/api/config/packages/sentry.yml
+++ b/projects/flora/api/config/packages/sentry.yml
@@ -2,12 +2,20 @@ when@prod:
   monolog:
     handlers:
       sentry:
-        fill_extra_context: true
-        hub_id: Sentry\State\HubInterface
-        level: !php/const Monolog\Logger::ERROR
-        type: sentry
+        type: service
+        id: Sentry\Monolog\Handler
 
   sentry:
     dsn: '%env(SENTRY_DSN)%'
     register_error_handler: false
     register_error_listener: false
+
+  # monolog-bundle 4 removed the built-in "sentry" handler type. Register the
+  # Sentry handler as a service and wire it through the "service" handler above.
+  # https://docs.sentry.io/platforms/php/guides/symfony/integrations/monolog/
+  services:
+    Sentry\Monolog\Handler:
+      arguments:
+        $hub: '@Sentry\State\HubInterface'
+        $level: !php/const Monolog\Logger::ERROR
+        $fillExtraContext: true

--- a/projects/tera/api/config/packages/sentry.yml
+++ b/projects/tera/api/config/packages/sentry.yml
@@ -2,13 +2,19 @@ when@prod:
   monolog:
     handlers:
       sentry:
-        fill_extra_context: true
-        hub_id: Sentry\State\HubInterface
-        level: !php/const Monolog\Logger::ERROR
-        type: sentry
+        type: service
+        id: Sentry\Monolog\Handler
   sentry:
     dsn: '%env(SENTRY_DSN)%'
     register_error_handler: false
-    #        If you are using Monolog, you also need these additional configuration and services to log the errors correctly:
-    #        https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration
     register_error_listener: false
+
+  # monolog-bundle 4 removed the built-in "sentry" handler type. Register the
+  # Sentry handler as a service and wire it through the "service" handler above.
+  # https://docs.sentry.io/platforms/php/guides/symfony/integrations/monolog/
+  services:
+    Sentry\Monolog\Handler:
+      arguments:
+        $hub: '@Sentry\State\HubInterface'
+        $level: !php/const Monolog\Logger::ERROR
+        $fillExtraContext: true


### PR DESCRIPTION
## What

Fix the prod Docker build failure for the backend APIs by replacing the removed monolog `sentry` handler type with a `type: service` handler.

## Why

`symfony/monolog-bundle` **4.0.0 removed the built-in `sentry` (and `raven`) handler types** ([changelog](https://github.com/symfony/monolog-bundle/blob/master/CHANGELOG.md): *"Remove `sentry` and `raven` types, use a `service` type with `sentry/sentry-symfony` instead"*). All three APIs are locked to monolog-bundle **v4.0.2** but still configured the handler the old way:

```yaml
sentry:
  type: sentry
  hub_id: Sentry\State\HubInterface
  fill_extra_context: true
  level: !php/const Monolog\Logger::ERROR
```

This makes the **prod container** fail to compile:

```
Unrecognized options "fill_extra_context, hub_id" under "monolog.handlers.sentry"
```

It surfaced as a red build (`bin/console cache:clear` / `assets:install`) once the APIs were wired into the unified build-and-push workflow in #165 — the first time the prod container is compiled in CI. The bug was latent in all three APIs (`espace`, `tera`, `flora`), which shared the identical config; `espace-api` was just the affected project in that push.

Failing job: https://github.com/lychen-lab/lychen/actions/runs/27503631167/job/81290887303

## How

Register `Sentry\Monolog\Handler` as a **prod-only** service (hub, `ERROR` level, `fillExtraContext: true` — matching the old behavior and the SDK's constructor) and reference it via a `type: service` monolog handler, as recommended by the monolog-bundle 4 upgrade notes and the [Sentry Symfony Monolog docs](https://docs.sentry.io/platforms/php/guides/symfony/integrations/monolog/). Kept prod-only because `SentryBundle` / `Sentry\State\HubInterface` is only enabled in prod.

## Verification

Built the `frankenphp_prod` target locally (native arm64). The previously-failing step now passes and the image builds (exit 0):

```
#23 [frankenphp_prod 11/11] RUN ... bin/console assets:install
#23  [OK] All assets were successfully installed.
#23 DONE 0.2s
```

## Note for reviewers (separate, non-blocking)

With monolog fixed, `cache:clear` gets far enough to hit a *pre-existing* Doctrine DBAL warmup error (`Invalid platform version ""`) because no `server_version` is configured and there's no DB at build time. It does **not** fail the build (that `RUN` has no `set -e`) and affects `tera` too, so the prod cache simply warms at runtime as it does today. Out of scope here; happy to follow up by configuring a `server_version` so the cache warms at build time across all APIs.