### PR TITLE
ci: enforce Conventional Commits on PR titles

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,82 @@
+name: 'PR Title Lint'
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+
+jobs:
+  lint-pr-title:
+    name: 'Validate PR title (Conventional Commits)'
+    runs-on: ubuntu-latest
+    steps:
+      # We squash-merge PRs, so the PR title becomes the commit subject that
+      # release-please parses to compute the next version + changelog. Enforce
+      # Conventional Commits here so every merged title stays machine-readable.
+      # Keep `types` in sync with changelog-sections in release-please-config.json.
+      - uses: 'amannn/action-semantic-pull-request@v6'
+        id: lint
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            revert
+            docs
+            chore
+            ci
+            test
+            build
+            style
+
+      - name: 'Comment on invalid title'
+        if: always() && steps.lint.outcome == 'failure'
+        continue-on-error: true
+        uses: 'marocchino/sticky-pull-request-comment@v2'
+        with:
+          header: pr-title-lint-error
+          message: |
+            ## ⚠️ PR title is not a valid Conventional Commit
+
+            This repository squash-merges PRs, so the **PR title becomes the commit
+            message** that drives automated versioning and the changelog. Please
+            update the title to:
+
+            ```
+            <type>(optional scope): <description>
+            ```
+
+            Allowed types: `feat`, `fix`, `perf`, `refactor`, `revert`, `docs`,
+            `chore`, `ci`, `test`, `build`, `style`.
+
+            Examples: `feat(tera-api): add CSV export endpoint`,
+            `fix(tera-app): correct locale fallback`.
+
+            <details><summary>Validation error</summary>
+
+            ```
+            ${{ steps.lint.outputs.error_message }}
+            ```
+
+            </details>
+
+      - name: 'Clear the comment once the title is valid'
+        if: always() && steps.lint.outcome == 'success'
+        continue-on-error: true
+        uses: 'marocchino/sticky-pull-request-comment@v2'
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
## What & why

**PR 2** of the versioning plan. Adds a PR-title lint check using [`amannn/action-semantic-pull-request@v6`](https://github.com/amannn/action-semantic-pull-request).

We squash-merge PRs, so the **PR title becomes the squash commit subject** — which is exactly what `release-please` (added in #166) parses to compute the next version and build the changelog. If a title isn't a valid Conventional Commit, the version bump/changelog silently drift. This check closes that gap.

## What it does

- Validates the PR title against Conventional Commits on `opened`/`edited`/`reopened`/`synchronize`.
- Allowed **types** are kept in sync with `changelog-sections` in `release-please-config.json`: `feat`, `fix`, `perf`, `refactor`, `revert`, `docs`, `chore`, `ci`, `test`, `build`, `style`.
- **Scopes stay optional and freeform** (e.g. `feat(tera-api): …`) — no scope allowlist enforced.
- On failure it posts a sticky comment explaining the convention + the exact error, and removes the comment once the title is fixed (comment steps are `continue-on-error`, so only the validation governs pass/fail).

## Reviewer notes

- ⚠️ **To actually block merges, add "Validate PR title (Conventional Commits)" as a required status check** in branch protection for `main`. Without that, the check runs and reports but won't gate merges.
- Uses `on: pull_request` (matches the repo's other PR workflows). The failure-comment needs `pull-requests: write`, which `GITHUB_TOKEN` has for internal-branch PRs; fork PRs would need `pull_request_target` instead — not relevant for the current internal-branch workflow.

## Next

Phase 1 is then complete (versioning + changelog + reliable titles). Remaining: **Phase 2** — immutable, version/SHA-pinned Docker image tags + pinned Dokploy deploys (rollback + traceability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)