### PR TITLE
ci: start the release line at 0.x (release-as 0.1.0)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,11 +3,13 @@
   "bootstrap-sha": "3fe502e88e2ef6dabb41f557787c459a90f01c4a",
   "include-component-in-tag": false,
   "separate-pull-requests": false,
+  "bump-minor-pre-major": true,
   "packages": {
     ".": {
       "release-type": "simple",
       "package-name": "lychen",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "release-as": "0.1.0"
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## What & why

The platform is pre-stable, so we want to iterate on **`0.x.x`** rather than release-please's default initial **`1.0.0`** (which is what the current release PR #169 proposes).

Two config changes to `release-please-config.json`:

| Key | Effect |
|---|---|
| `release-as: "0.1.0"` (per-package) | Forces the next release to exactly **`0.1.0`**. |
| `bump-minor-pre-major: true` (top-level) | While major is `0`: `fix`→patch, `feat`→minor, and a **breaking change bumps the minor (`0.x.0`), not `1.0.0`**. Keeps us in `0.x` until we choose to go stable. |

## ⚠️ Required follow-up (don't skip)

`release-as` is **sticky** — it forces *every* run to `0.1.0`. Once this merges and **`v0.1.0` is tagged**, a small follow-up PR must **remove the `release-as` line** so normal computation resumes (`bump-minor-pre-major` stays). Without it, all future releases freeze at `0.1.0`.

## Sequence

1. Merge this PR → the `Release` workflow re-runs and **auto-updates release PR #169 from `1.0.0` → `0.1.0`** (no need to touch #169 manually).
2. Merge #169 → tags **`v0.1.0`** + GitHub Release.
3. Open the follow-up to drop `release-as`.

When we're ready to declare stability later, we go `0.x` → `1.0.0` deliberately (a breaking change once `bump-minor-pre-major` is removed, or another one-shot `release-as`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)