### PR TITLE
ci: authenticate release-please via GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,26 +10,32 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Write permissions now come from the GitHub App installation token minted
+# below (lychen-release-bot), not from GITHUB_TOKEN, so this stays minimal.
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     name: 'Release Please'
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived (~1h) installation token from the org-owned GitHub App.
+      # Authoring the release PR with an App token (instead of GITHUB_TOKEN) means
+      # the PR TRIGGERS other workflows (CI runs on the release PR) and does not
+      # depend on the org "Actions can create PRs" policy.
+      # Requires repo secrets RELEASE_APP_CLIENT_ID + RELEASE_APP_PRIVATE_KEY.
+      - uses: 'actions/create-github-app-token@v3'
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       # Maintains a single rolling "release PR" for the whole monorepo.
       # Merging it bumps version.txt + .release-please-manifest.json,
       # updates CHANGELOG.md, and creates the `vX.Y.Z` git tag + GitHub Release.
-      #
-      # NOTE: GITHUB_TOKEN is sufficient today because deploys trigger on push
-      # to main (the release-PR merge), not on the tag. If a later phase adds
-      # tag-triggered workflows (e.g. prod promotion), swap this for a PAT/app
-      # token so the tag event can trigger them.
       - uses: 'googleapis/release-please-action@v4'
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: 'release-please-config.json'
           manifest-file: '.release-please-manifest.json'


### PR DESCRIPTION
> **Draft until the App + secrets exist** (see prerequisites). Merging before the secrets are set will make the next `Release` run fail.

## What & why

Switches `release.yml` from `GITHUB_TOKEN` to a short-lived installation token minted from an org-owned GitHub App (`lychen-release-bot`) via [`actions/create-github-app-token@v3`](https://github.com/actions/create-github-app-token).

- ✅ Release PRs authored by an App token **trigger other workflows** → CI finally runs on the release PR. (`GITHUB_TOKEN`-created PRs don't trigger workflows — that's why #169 had zero checks.)
- ✅ No longer depends on the org-wide *"Allow Actions to create PRs"* policy (can be re-locked afterwards).
- ✅ No PAT expiry — the token is short-lived (~1h) and auto-scoped to this repo's installation.

## Prerequisites before marking ready / merging

1. Create the org GitHub App `lychen-release-bot` with **Contents: R/W**, **Pull requests: R/W**, **Issues: R/W**.
2. Install it on `lychen-lab/lychen`.
3. Add repo secrets:
   - `RELEASE_APP_CLIENT_ID` — the App's Client ID
   - `RELEASE_APP_PRIVATE_KEY` — the full `.pem` contents

Once those are in place, mark this PR **Ready for review** and merge.

## After merge (optional)

The org policy *"Allow GitHub Actions to create and approve pull requests"* is no longer required by release-please and can be reverted at the org level if you want it locked down again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)