### PR TITLE
ci: tag API images by SHA and parametrize compose image tags

### DIFF
--- a/.moon/tasks/tag-symfony.yml
+++ b/.moon/tasks/tag-symfony.yml
@@ -33,7 +33,7 @@ tasks:
     deps:
       - common-mailpit:up
   docker-buildx:
-    command: docker buildx build $projectRoot --cache-from ghcr.io/lychen-lab/$project:latest --platform linux/arm64,linux/amd64 --target frankenphp_prod -t ghcr.io/lychen-lab/$project:latest --push
+    command: docker buildx build $projectRoot --cache-from ghcr.io/lychen-lab/$project:latest --platform linux/arm64,linux/amd64 --target frankenphp_prod -t ghcr.io/lychen-lab/$project:latest -t ghcr.io/lychen-lab/$project:${GITHUB_SHA} --push
     deps:
       - ci-copy-packages
     options:

--- a/projects/espace/api/compose.yml
+++ b/projects/espace/api/compose.yml
@@ -37,7 +37,7 @@ services:
             SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
             TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-example\.com|localhost}|php$$}
             TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}
-        image: ${IMAGES_PREFIX:-}espace-api
+        image: ${IMAGES_PREFIX:-}espace-api:${IMAGE_TAG:-latest}
         restart: unless-stopped
         volumes:
             - caddy_data:/data

--- a/projects/espace/app/compose.yml
+++ b/projects/espace/app/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
     env_file: .env
-    image: ghcr.io/lychen-lab/lychen/espace-app:latest
+    image: ghcr.io/lychen-lab/lychen/espace-app:${IMAGE_TAG:-latest}
     pull_policy: always
     restart: unless-stopped

--- a/projects/espace/website/compose.yml
+++ b/projects/espace/website/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
     env_file: .env
-    image: ghcr.io/lychen-lab/lychen/espace-website:latest
+    image: ghcr.io/lychen-lab/lychen/espace-website:${IMAGE_TAG:-latest}
     pull_policy: always
     restart: unless-stopped

--- a/projects/flora/api/compose.yml
+++ b/projects/flora/api/compose.yml
@@ -29,7 +29,7 @@ services:
       SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
       TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-example\.com|localhost}|php$$}
       TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}
-    image: ${IMAGES_PREFIX:-}flora-api
+    image: ${IMAGES_PREFIX:-}flora-api:${IMAGE_TAG:-latest}
     restart: unless-stopped
     volumes:
       - caddy_data:/data

--- a/projects/tera/api/compose.yml
+++ b/projects/tera/api/compose.yml
@@ -29,7 +29,7 @@ services:
       SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
       TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-example\.com|localhost}|php$$}
       TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}
-    image: ${IMAGES_PREFIX:-}tera-api
+    image: ${IMAGES_PREFIX:-}tera-api:${IMAGE_TAG:-latest}
     restart: unless-stopped
     volumes:
       - caddy_data:/data

--- a/projects/website/compose.yml
+++ b/projects/website/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
     env_file: .env
-    image: ghcr.io/lychen-lab/lychen/website:latest
+    image: ghcr.io/lychen-lab/lychen/website:${IMAGE_TAG:-latest}
     pull_policy: always
     restart: unless-stopped


### PR DESCRIPTION
## What & why

**Phase 2a** toward immutable, rollback-able deploys. Today every deploy pulls `:latest` and the **API images don't even have a SHA tag** — so there's no way to pin or roll back. This lays the groundwork.

**Fully backward-compatible:** image tags still default to `:latest`, so deploy behaviour is unchanged until Phase 2b wires the deploy to set `IMAGE_TAG`.

## Changes

- **`tag-symfony` `docker-buildx`**: also pushes `:${GITHUB_SHA}` (was `:latest` only) → API images are now addressable by an immutable per-build tag, like the frontend images already are (`tag-docker` pushes `:sha` + `:latest`).
- **`compose.yml` of the 6 deployed projects**: image reference is now `…:${IMAGE_TAG:-latest}` so a specific build can be pinned at deploy time:
  - Frontends: `website`, `espace-app`, `espace-website`
  - APIs: `tera-api`, `espace-api`, `flora-api`

## Scope

Only the 6 projects actually in the build+deploy pipeline. `tera-app` / `tera-website` / `robust-website` / `storybook` are **intentionally excluded** (not wired into CD).

## Next — Phase 2b (separate PR)

Wire `deploy.yml` to set the Dokploy compose env `IMAGE_TAG=<sha>` (via `compose.update`) before `compose.deploy`, so each deploy pins an immutable image. Rollback = redeploy a previous SHA. Pending one check: whether Dokploy's `compose.update` merges or replaces the env (so we don't clobber `IMAGES_PREFIX`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)