### PR TITLE
ci: drop release-as now that v0.1.0 is tagged

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,8 +8,7 @@
     ".": {
       "release-type": "simple",
       "package-name": "lychen",
-      "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.0"
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## What & why

`release-as: "0.1.0"` (added in #170) was a **one-shot** to force the first release onto the `0.x` line instead of release-please's default `1.0.0`. Now that **`v0.1.0` is tagged + released** and the manifest is at `0.1.0`, it must be removed — otherwise release-please would force **every** future release back to `0.1.0`.

## Change

- Remove `release-as` from `release-please-config.json`.
- **`bump-minor-pre-major: true` stays** → the line keeps iterating in `0.x`: `fix`→patch (`0.1.1`), `feat`→minor (`0.2.0`), breaking→minor (stays sub-`1.0.0`).

Going stable later = a deliberate move to `1.0.0` (drop `bump-minor-pre-major`, or a one-shot `release-as: 1.0.0`).

## After merge

The next `feat:`/`fix:` on `main` will make release-please open a fresh release PR computed from `v0.1.0` (e.g. `0.1.1` or `0.2.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)