### PR TITLE
feat(website): compléter la politique de confidentialité et supprimer la page CGU

### DIFF
--- a/libs/vue/components-website/views/privacy-policy/i18n/en-US.json
+++ b/libs/vue/components-website/views/privacy-policy/i18n/en-US.json
@@ -1,30 +1,70 @@
 {
   "meta": {
     "title": "Privacy Policy",
-    "description": "Privacy Policy regarding personal data for the Lychen Association."
+    "description": "Privacy policy of the Lychen association: data controller, data collected, cookies, retention periods and how to exercise your rights under the GDPR."
   },
   "title": "Privacy Policy",
   "last_update": "Last updated: {date}",
   "sections": [
     {
-      "title": "Data Controller",
-      "content": "The data controller is the Lychen Association.\nHeadquarters: 1 ALLEE DU TRELOD 74000 ANNECY, France\nContact: dpo@lychen.org or contact@lychen.org"
+      "title": "Introduction",
+      "content": "The Lychen association is committed to respecting your privacy and protecting your personal data. This privacy policy explains, in a clear and transparent manner, how your data is collected and processed when you browse this website.\nThis is an informational website (showcase site). It does not offer account creation or online sales. This document is established in accordance with Regulation (EU) 2016/679 of 27 April 2016 (GDPR) and French Law No. 78-17 of 6 January 1978 on data processing, data files and individual liberties."
     },
     {
-      "title": "Data Collected",
-      "content": "Our website is a static site that does not require user accounts. We do not collect personal data directly through the site forms currently (unless otherwise stated). Use of the site does not require providing personal data."
+      "title": "Site publisher and data controller",
+      "content": "This website is published by the Lychen association, a non-profit association governed by the French law of 1 July 1901.\nRegistered office: 1 allée du Trélod, 74000 Annecy, France\nSIREN: 993 140 904 — SIRET: 993 140 904 00018\nPublication director: the association's presidency\nThe controller of personal data is the Lychen association, represented by its presidency.\nContact: contact@lychen.org"
     },
     {
-      "title": "Cookies",
-      "content": "We do not use tracking cookies or marketing cookies. Technical cookies may be used by the hosting provider for security and load balancing purposes, which do not require consent."
+      "title": "Data Protection Officer (DPO)",
+      "content": "For any question regarding the processing of your personal data or the exercise of your rights, you can contact our Data Protection Officer:\nBy email: dpo@lychen.org\nBy post: Association Lychen — DPO, 1 allée du Trélod, 74000 Annecy, France"
     },
     {
-      "title": "User Rights",
-      "content": "In accordance with the GDPR and French law, you have the right to access, rectify, delete, and port your data. You also have the right to object to or limit processing. To exercise these rights, please contact our Data Protection Officer (DPO) at: dpo@lychen.org."
+      "title": "Data collected",
+      "content": "This website is static and informational. No user account is required and no personal data is collected through forms on this site (unless otherwise explicitly stated at the point of collection).\nWhile you browse, technical connection data (IP address, date and time of the request, browser type, pages visited) may be automatically recorded in the hosting provider's logs, for security and proper-operation purposes.\nIf you contact us directly by email, we process the data you provide on your own initiative (email address, message content) in order to respond to your request."
     },
     {
-      "title": "Right to Complain",
-      "content": "If you believe your rights are not respecting, you can file a complaint with the CNIL (Commission Nationale de l'Informatique et des Libertés) in France."
+      "title": "Purposes of processing",
+      "content": "The data mentioned above is processed for the following purposes:\n- to ensure the operation, security and availability of the website;\n- to respond to requests you send us by email;\n- where applicable, to compile strictly anonymous traffic statistics.\nYour data is not subject to any automated decision-making or profiling."
+    },
+    {
+      "title": "Legal basis for processing",
+      "content": "In accordance with Article 6 of the GDPR, the processing relies on the following legal bases:\n- the legitimate interest of the association in ensuring the security and proper operation of the site (technical logs);\n- the performance of measures taken at your request when you contact us by email;\n- your consent, where it is specifically required and obtained."
+    },
+    {
+      "title": "Cookies and trackers",
+      "content": "This website does not use any advertising tracking cookies or audience-measurement tools that require your consent.\nOnly cookies and technical storage strictly necessary for the proper functioning of the site may be used; these are exempt from consent in accordance with the recommendations of the CNIL (the French data protection authority). Your display preferences (language, light or dark theme) are stored locally on your device and are never transmitted to third parties.\nYou can configure your browser at any time to block or delete these items."
+    },
+    {
+      "title": "Recipients of the data",
+      "content": "Your data is never sold, rented or transferred to third parties for commercial purposes.\nIt is accessible only to authorised members of the association who need to know it, as well as to our hosting provider acting as a processor, solely for the technical operation and security of the site."
+    },
+    {
+      "title": "Hosting and transfers outside the EU",
+      "content": "The technical data related to the site is hosted within the European Union. No transfer of personal data outside the European Union is carried out in the course of operating this website."
+    },
+    {
+      "title": "Retention period",
+      "content": "Your data is kept for no longer than is necessary for the purposes for which it is processed:\n- connection logs (IP address, technical logs): up to 12 months;\n- contact emails: for the time needed to handle your request, then archived or deleted no later than 3 years after our last exchange;\n- locally stored preferences: until you delete them yourself (by clearing your browser storage)."
+    },
+    {
+      "title": "Data security",
+      "content": "The association implements appropriate technical and organisational measures to protect your data against loss, alteration, disclosure or unauthorised access. Exchanges with the site are encrypted using the HTTPS (TLS) protocol, and access to data is restricted to authorised persons only."
+    },
+    {
+      "title": "Your rights",
+      "content": "In accordance with the GDPR and the French Data Protection Act, you have the following rights over your data: the right of access, rectification, erasure, restriction of processing, portability, as well as the right to object to processing and the right to set guidelines regarding the fate of your data after your death.\nTo exercise these rights, send your request to our DPO at: dpo@lychen.org. Proof of identity may be requested. We undertake to respond within one month of receiving your request."
+    },
+    {
+      "title": "Right to lodge a complaint with the CNIL",
+      "content": "If, after contacting us, you believe that your rights are not respected, you have the right to lodge a complaint with the French Data Protection Authority (CNIL):\nCNIL — 3 place de Fontenoy, TSA 80715, 75334 Paris Cedex 07, France\nWebsite: www.cnil.fr"
+    },
+    {
+      "title": "Changes to this policy",
+      "content": "This privacy policy may change in order to reflect legal, regulatory or technical developments. The date of the last update appears at the top of the page. We encourage you to review it regularly."
+    },
+    {
+      "title": "Contact",
+      "content": "For any question regarding this privacy policy or the processing of your personal data, you can write to us at: contact@lychen.org (or dpo@lychen.org for requests relating to data protection)."
     }
   ]
 }

--- a/libs/vue/components-website/views/privacy-policy/i18n/fr-FR.json
+++ b/libs/vue/components-website/views/privacy-policy/i18n/fr-FR.json
@@ -1,30 +1,70 @@
 {
   "meta": {
     "title": "Politique de Confidentialité",
-    "description": "Politique de Confidentialité concernant les données personnelles de l'association Lychen."
+    "description": "Politique de confidentialité de l'association Lychen : responsable du traitement, données collectées, cookies, durées de conservation et exercice de vos droits conformément au RGPD."
   },
   "title": "Politique de Confidentialité",
   "last_update": "Dernière mise à jour : {date}",
   "sections": [
     {
-      "title": "Responsable du traitement",
-      "content": "Le responsable du traitement des données est l'Association Lychen.\nSiège social : 1 ALLEE DU TRELOD 74000 ANNECY\nContact DPO : dpo@lychen.org\nContact générique : contact@lychen.org"
+      "title": "Préambule",
+      "content": "L'association Lychen attache une grande importance au respect de votre vie privée et à la protection de vos données à caractère personnel. La présente politique de confidentialité a pour objet de vous informer, de manière claire et transparente, sur la façon dont vos données sont collectées et traitées lorsque vous consultez ce site.\nLe site est un site informatif (site vitrine). Il ne propose ni création de compte, ni vente en ligne. Le présent document est établi conformément au Règlement (UE) 2016/679 du 27 avril 2016 (RGPD) et à la loi n° 78-17 du 6 janvier 1978 relative à l'informatique, aux fichiers et aux libertés, dite « Informatique et Libertés »."
+    },
+    {
+      "title": "Éditeur du site et responsable du traitement",
+      "content": "Le présent site est édité par l'association Lychen, association déclarée régie par la loi du 1er juillet 1901.\nSiège social : 1 allée du Trélod, 74000 Annecy, France\nSIREN : 993 140 904 — SIRET : 993 140 904 00018\nDirecteur de la publication : la présidence de l'association\nLe responsable du traitement des données à caractère personnel est l'association Lychen, représentée par sa présidence.\nContact : contact@lychen.org"
+    },
+    {
+      "title": "Délégué à la protection des données (DPO)",
+      "content": "Pour toute question relative au traitement de vos données personnelles ou à l'exercice de vos droits, vous pouvez contacter notre Délégué à la Protection des Données :\nPar courriel : dpo@lychen.org\nPar courrier : Association Lychen — DPO, 1 allée du Trélod, 74000 Annecy, France"
     },
     {
       "title": "Données collectées",
-      "content": "Notre site internet est un site statique informatif. Nous ne collectons pas de données personnelles nominatives via des formulaires sur ce site (sauf mention contraire explicite). La simple navigation sur le site ne nécessite pas la fourniture de données personnelles."
+      "content": "Ce site est statique et informatif. Aucun compte utilisateur n'est requis et aucune donnée nominative n'est collectée via des formulaires sur ce site (sauf mention contraire explicite à l'endroit de la collecte).\nLors de votre navigation, des données techniques de connexion (adresse IP, date et heure de la requête, type de navigateur, pages consultées) peuvent être enregistrées automatiquement dans les journaux de l'hébergeur, à des fins de sécurité et de bon fonctionnement.\nSi vous nous contactez directement par courriel, nous traitons les données que vous nous communiquez de votre propre initiative (adresse électronique, contenu de votre message) afin de répondre à votre demande."
     },
     {
-      "title": "Cookies",
-      "content": "Nous n'utilisons pas de cookies de traçage publicitaire ou de mesure d'audience nécessitant un consentement. Des cookies techniques peuvent être déposés par l'hébergeur à des fins de sécurité et de bon fonctionnement, exemptés de consentement selon les recommandations de la CNIL."
+      "title": "Finalités du traitement",
+      "content": "Les données susmentionnées sont traitées pour les finalités suivantes :\n- assurer le fonctionnement, la sécurité et la disponibilité du site ;\n- répondre aux demandes que vous nous adressez par courriel ;\n- établir, le cas échéant, des statistiques de fréquentation strictement anonymes.\nVos données ne font l'objet d'aucune décision automatisée ni d'aucun profilage."
+    },
+    {
+      "title": "Base légale du traitement",
+      "content": "Conformément à l'article 6 du RGPD, les traitements reposent sur les bases légales suivantes :\n- l'intérêt légitime de l'association à garantir la sécurité et le bon fonctionnement du site (journaux techniques) ;\n- l'exécution de mesures prises à votre demande, lorsque vous nous contactez par courriel ;\n- votre consentement, lorsqu'il est spécifiquement requis et recueilli."
+    },
+    {
+      "title": "Cookies et traceurs",
+      "content": "Ce site n'utilise aucun cookie de traçage publicitaire ni aucun outil de mesure d'audience nécessitant votre consentement.\nSeuls peuvent être utilisés des cookies et stockages techniques strictement nécessaires au bon fonctionnement du site, exemptés de consentement conformément aux recommandations de la CNIL. Vos préférences d'affichage (langue, thème clair ou sombre) sont enregistrées localement sur votre appareil et ne sont jamais transmises à des tiers.\nVous pouvez à tout moment configurer votre navigateur pour bloquer ou supprimer ces éléments."
+    },
+    {
+      "title": "Destinataires des données",
+      "content": "Vos données ne sont ni vendues, ni louées, ni cédées à des tiers à des fins commerciales.\nElles sont accessibles uniquement aux personnes habilitées de l'association ayant besoin d'en connaître, ainsi qu'à notre hébergeur agissant en qualité de sous-traitant, pour les seuls besoins techniques de fonctionnement et de sécurité du site."
+    },
+    {
+      "title": "Hébergement et transferts hors UE",
+      "content": "Les données techniques liées au site sont hébergées au sein de l'Union européenne. Aucun transfert de données à caractère personnel en dehors de l'Union européenne n'est effectué dans le cadre de l'exploitation de ce site."
+    },
+    {
+      "title": "Durée de conservation",
+      "content": "Vos données sont conservées pour une durée n'excédant pas celle nécessaire aux finalités pour lesquelles elles sont traitées :\n- journaux de connexion (adresse IP, logs techniques) : jusqu'à 12 mois ;\n- courriels de contact : le temps nécessaire au traitement de votre demande, puis archivés ou supprimés au plus tard 3 ans après notre dernier échange ;\n- préférences enregistrées localement : jusqu'à leur effacement par vos soins (vidage du stockage de votre navigateur)."
+    },
+    {
+      "title": "Sécurité des données",
+      "content": "L'association met en œuvre les mesures techniques et organisationnelles appropriées afin de protéger vos données contre toute perte, altération, divulgation ou accès non autorisé. Les échanges avec le site sont chiffrés via le protocole HTTPS (TLS), et l'accès aux données est limité aux seules personnes habilitées."
     },
     {
       "title": "Vos droits",
-      "content": "Conformément au RGPD et à la loi Informatique et Libertés, vous disposez d'un droit d'accès, de rectification, d'effacement, de portabilité, de limitation et d'opposition au traitement de vos données. Pour exercer ces droits, contactez notre Délégué à la Protection des Données (DPO) : dpo@lychen.org."
+      "content": "Conformément au RGPD et à la loi Informatique et Libertés, vous disposez des droits suivants sur vos données : droit d'accès, de rectification, d'effacement, de limitation du traitement, de portabilité, ainsi que d'opposition au traitement et le droit de définir des directives relatives au sort de vos données après votre décès.\nPour exercer ces droits, adressez votre demande à notre DPO : dpo@lychen.org. Une preuve d'identité pourra vous être demandée. Nous nous engageons à vous répondre dans un délai d'un mois à compter de la réception de votre demande."
     },
     {
-      "title": "Réclamation",
-      "content": "Si vous estimez, après nous avoir contactés, que vos droits ne sont pas respectés, vous pouvez adresser une réclamation auprès de la CNIL."
+      "title": "Réclamation auprès de la CNIL",
+      "content": "Si vous estimez, après nous avoir contactés, que vos droits ne sont pas respectés, vous disposez du droit d'introduire une réclamation auprès de la Commission Nationale de l'Informatique et des Libertés (CNIL) :\nCNIL — 3 place de Fontenoy, TSA 80715, 75334 Paris Cedex 07\nSite web : www.cnil.fr"
+    },
+    {
+      "title": "Modification de la politique",
+      "content": "La présente politique de confidentialité peut être amenée à évoluer afin de tenir compte des changements légaux, réglementaires ou techniques. La date de dernière mise à jour figure en tête de page. Nous vous invitons à la consulter régulièrement."
+    },
+    {
+      "title": "Contact",
+      "content": "Pour toute question relative à la présente politique de confidentialité ou au traitement de vos données personnelles, vous pouvez nous écrire à l'adresse suivante : contact@lychen.org (ou dpo@lychen.org pour les demandes relatives à la protection des données)."
     }
   ]
 }

--- a/projects/website/src/layouts/TheFooter.vue
+++ b/projects/website/src/layouts/TheFooter.vue
@@ -11,17 +11,13 @@ import { defineAsyncComponent } from 'vue';
 
 import { CONFIG } from './i18n';
 import { usePrefixedI18n } from '@lychen/vue-i18n/composables/useI18nExtended';
-import { ROUTE_TERMS_OF_USE } from '@lychen/vue-components-website/views/terms-of-use';
 import { ROUTE_PRIVACY_POLICY } from '@lychen/vue-components-website/views/privacy-policy';
 
 const FooterMain = defineAsyncComponent(
   () => import('@lychen/vue-components-website/footer/FooterMain.vue'),
 );
 
-const legalMenus = [
-  { title: "Conditions générales d'utilisation", to: { name: ROUTE_TERMS_OF_USE.name } },
-  { title: 'Protection des données', to: { name: ROUTE_PRIVACY_POLICY.name } },
-];
+const legalMenus = [{ title: 'Protection des données', to: { name: ROUTE_PRIVACY_POLICY.name } }];
 
 const { t } = usePrefixedI18n(CONFIG);
 </script>

--- a/projects/website/src/router/routes.ts
+++ b/projects/website/src/router/routes.ts
@@ -9,7 +9,6 @@ import { ROUTE_PARTNERSHIPS } from '@/views/partnerships';
 import { ROUTE_CAREER } from '@/views/career';
 import { ROUTE_LABEL } from '@/views/label';
 import { ROUTE_PRIVACY_POLICY } from '@lychen/vue-components-website/views/privacy-policy';
-import { ROUTE_TERMS_OF_USE } from '@lychen/vue-components-website/views/terms-of-use';
 
 const routes: RouteRecordRaw[] = [
   {
@@ -22,7 +21,6 @@ const routes: RouteRecordRaw[] = [
       ROUTE_TEAM,
       ROUTE_PRIVACY_POLICY,
       ROUTE_APPLICATIONS,
-      ROUTE_TERMS_OF_USE,
       ROUTE_PARTNERSHIPS,
       ROUTE_CAREER,
       ROUTE_LABEL,


### PR DESCRIPTION
## Contexte

Le site `website` est un site vitrine. Cette PR enrichit la page **Politique de confidentialité** et retire la page **CGU** (non nécessaire pour un site vitrine sans compte ni transaction).

## Ce qui change

### 📄 Politique de confidentialité complétée (FR + EN)
La vue partagée [`privacy-policy`](libs/vue/components-website/views/privacy-policy/) passe de **5 → 15 sections** conformes RGPD (Règlement UE 2016/679 + loi Informatique et Libertés), en s'appuyant sur les modèles CNIL/RGPD standards :

> Préambule · Éditeur & responsable du traitement · DPO · Données collectées · Finalités · Base légale · Cookies & traceurs · Destinataires · Hébergement & transferts hors UE · Durée de conservation · Sécurité · Vos droits · Réclamation CNIL · Modification · Contact

- Adaptée au contexte **site vitrine statique** (pas de compte, pas de formulaire, pas de cookie de traçage ; préférences langue/thème stockées localement).
- Coordonnées réelles depuis les constantes (`contact@lychen.org`, `dpo@lychen.org`, SIREN/SIRET, siège d'Annecy).
- Les **mentions légales** (éditeur, SIREN/SIRET, directeur de publication, hébergeur) sont intégrées à la section « Éditeur du site et responsable du traitement » afin de ne pas les perdre avec le retrait de la CGU.
- Correction d'une faute existante en EN (« are not respecting » → « are not respected »).

### 🗑️ Suppression de la page CGU du projet website
- [`routes.ts`](projects/website/src/router/routes.ts) : retrait de l'import et de `ROUTE_TERMS_OF_USE`.
- [`TheFooter.vue`](projects/website/src/layouts/TheFooter.vue) : retrait du lien « Conditions générales d'utilisation » (il ne reste que « Protection des données »).
- La vue partagée `terms-of-use` est **conservée** car `projects/espace/website` la référence toujours.

## Vérifications
- ✅ `website:lint` · `website:typecheck` · `website:format`
- ✅ JSON i18n valides (15 sections FR/EN synchronisées) + Prettier

## Notes pour la review / à valider
- **Hébergement** : la politique mentionne un hébergement **au sein de l'UE / sans transfert hors UE** — à confirmer selon l'hébergeur réel.
- **Mentions légales** : intégrées à la politique de confidentialité. Une page dédiée « Mentions légales » (obligatoire LCEN) peut être ajoutée si souhaité.
- **Portée** : `projects/espace/website` conserve sa propre route + lien CGU — à retirer également si ce site doit suivre la même logique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)