### PR TITLE
ci: skip no-op production redeploys (compare image digests)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -67,17 +67,49 @@ jobs:
         uses: 'moonrepo/setup-toolchain@v0'
       - name: Enable Corepack
         run: corepack enable
-      - name: 'Deploy'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Resolve Dokploy compose id'
+        id: dokploy
+        env:
+          DOKPLOY_SECRETS: ${{ toJSON(secrets) }}
+        run: |
+          PROJECT_ID_UPPERCASE=$(echo "${{ matrix.projects }}" | tr '[:lower:]-' '[:upper:]_')
+          SECRET_NAME="${PROJECT_ID_UPPERCASE}_DOKPLOY_ID"
+          echo "compose_id=$(echo "$DOKPLOY_SECRETS" | jq -r --arg key "$SECRET_NAME" '.[$key]')" >> "$GITHUB_OUTPUT"
+      # Skip no-op redeploys. With build-once-promote-many, an unchanged project's
+      # `:vX.Y.Z` tag points at the same digest as what is already running —
+      # redeploying it just restarts the container (a brief blip) for an identical
+      # image. Compare the target tag's digest against the tag the compose is
+      # currently pinned to (source of truth = what's actually deployed) and skip
+      # when they match. Fail-safe: anything unresolvable → changed → deploy.
+      - name: 'Detect image change'
+        id: changed
         env:
           DOKPLOY_API_TOKEN: ${{ secrets.DOKPLOY_API_TOKEN }}
           DOKPLOY_API_URL: ${{ secrets.DOKPLOY_API_URL }}
-          DOKPLOY_SECRETS: ${{ toJSON(secrets) }}
+          DOKPLOY_COMPOSE_ID: ${{ steps.dokploy.outputs.compose_id }}
+          PROJECT: ${{ matrix.projects }}
+          VERSION: ${{ needs.define-matrix.outputs.version }}
+        run: bash .moon/scripts/dokploy-prod-image-changed.sh
+      - name: 'Skip (image unchanged)'
+        if: ${{ steps.changed.outputs.changed == 'false' }}
+        run: |
+          echo "::notice title=Skipped ${{ matrix.projects }}::${{ matrix.projects }}:${{ needs.define-matrix.outputs.version }} is identical to the running image — no redeploy."
+      - name: 'Deploy'
+        if: ${{ steps.changed.outputs.changed != 'false' }}
+        env:
+          DOKPLOY_API_TOKEN: ${{ secrets.DOKPLOY_API_TOKEN }}
+          DOKPLOY_API_URL: ${{ secrets.DOKPLOY_API_URL }}
+          DOKPLOY_COMPOSE_ID: ${{ steps.dokploy.outputs.compose_id }}
           # Pin production to the release version. release.yml already re-tagged
           # each image `:<version>` from the build that shipped this release, so
           # this resolves to an immutable, reproducible image.
           IMAGE_TAG: ${{ needs.define-matrix.outputs.version }}
-        run: |
-          PROJECT_ID_UPPERCASE=$(echo "${{ matrix.projects }}" | tr '[:lower:]-' '[:upper:]_')
-          SECRET_NAME="${PROJECT_ID_UPPERCASE}_DOKPLOY_ID"
-          export DOKPLOY_COMPOSE_ID=$(echo "$DOKPLOY_SECRETS" | jq -r --arg key "$SECRET_NAME" '.[$key]')
-          moon run ${{ matrix.projects }}:dokploy-compose-deploy
+        run: moon run ${{ matrix.projects }}:dokploy-compose-deploy

--- a/.moon/scripts/dokploy-prod-image-changed.sh
+++ b/.moon/scripts/dokploy-prod-image-changed.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Decide whether deploying <PROJECT>@<VERSION> to production would actually change
+# the running image, or merely restart the container for an identical one.
+#
+# build-once-promote-many: a release re-tags EVERY dokploy project's image as
+# `:vX.Y.Z`, even projects unchanged since the previous release — their `:vX.Y.Z`
+# just points at the same digest as before. Redeploying such a project is a no-op
+# that still restarts the container (a brief production blip) for an identical
+# image. This compares the multi-arch index digest of the target tag against the
+# digest of the tag the Dokploy compose is CURRENTLY pinned to, so the prod deploy
+# can skip those no-ops.
+#
+# Source of truth = what is really running (the compose's current IMAGE_TAG, read
+# via compose.one — the same endpoint dokploy-compose-deploy.sh uses), so the
+# decision stays correct even if production skipped a release.
+#
+# Output: prints `changed=true` or `changed=false` and, when $GITHUB_OUTPUT is
+# set, appends the same line so a workflow step can gate the deploy on it. Every
+# decision (and the digests compared) is logged — no silent skips.
+#
+# Fail-safe: anything that cannot be resolved (no current tag, unreachable
+# registry, missing compose) yields `changed=true` so we deploy rather than risk
+# wrongly skipping. This also covers the first prod deploy and rollbacks to an
+# older version (whose digest differs → deploy).
+#
+# Required env:
+#   DOKPLOY_API_URL, DOKPLOY_API_TOKEN, DOKPLOY_COMPOSE_ID, PROJECT, VERSION
+# Optional env:
+#   DEFAULT_IMAGES_PREFIX  registry prefix to fall back on when the compose has
+#                          no IMAGES_PREFIX (default: ghcr.io/lychen-lab/lychen/)
+set -euo pipefail
+
+: "${DOKPLOY_API_URL:?DOKPLOY_API_URL is required}"
+: "${DOKPLOY_API_TOKEN:?DOKPLOY_API_TOKEN is required}"
+: "${DOKPLOY_COMPOSE_ID:?DOKPLOY_COMPOSE_ID is required}"
+: "${PROJECT:?PROJECT is required}"
+: "${VERSION:?VERSION is required}"
+
+DEFAULT_IMAGES_PREFIX="${DEFAULT_IMAGES_PREFIX:-ghcr.io/lychen-lab/lychen/}"
+
+# emit <true|false> <reason> — log the decision, expose it to the workflow, exit.
+emit() {
+  echo "→ ${PROJECT}: changed=$1 ($2)"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "changed=$1" >>"$GITHUB_OUTPUT"
+  fi
+  exit 0
+}
+
+# env_value <KEY> <env-blob> — first KEY=value out of a Dokploy compose env blob
+# (newline-separated KEY=value lines). Empty when absent.
+env_value() {
+  printf '%s\n' "$2" | grep -m1 "^$1=" | sed "s/^$1=//" || true
+}
+
+# image_digest <ref> — sha256 of the raw multi-arch index manifest, or empty when
+# the ref cannot be resolved. Hashing the bytes `imagetools inspect --raw` returns
+# is equivalent to the index digest, and is consistent for the target-vs-current
+# equality check regardless of registry-side canonicalisation. Always returns 0
+# (empty output on failure) so an unreachable registry can't abort the script —
+# the caller treats an empty digest as "cannot resolve" → fail-safe deploy.
+image_digest() {
+  local raw
+  raw="$(docker buildx imagetools inspect --raw "$1" 2>/dev/null)" || return 0
+  [ -n "$raw" ] || return 0
+  printf '%s' "$raw" | sha256sum | awk '{print "sha256:" $1}'
+}
+
+compose="$(curl -fsS -X GET "${DOKPLOY_API_URL}/compose.one?composeId=${DOKPLOY_COMPOSE_ID}" \
+  -H 'accept: application/json' \
+  -H "x-api-key: ${DOKPLOY_API_TOKEN}" || true)"
+
+env_blob="$(printf '%s' "$compose" | jq -r '.env // ""' 2>/dev/null || true)"
+current_tag="$(env_value IMAGE_TAG "$env_blob")"
+images_prefix="$(env_value IMAGES_PREFIX "$env_blob")"
+[ -n "$images_prefix" ] || images_prefix="$DEFAULT_IMAGES_PREFIX"
+
+[ -n "$current_tag" ] || emit true "no current IMAGE_TAG on the compose (first deploy?)"
+
+image_base="${images_prefix}${PROJECT}"
+target_ref="${image_base}:${VERSION}"
+current_ref="${image_base}:${current_tag}"
+
+target_digest="$(image_digest "$target_ref")"
+current_digest="$(image_digest "$current_ref")"
+echo "  target  ${target_ref} → ${target_digest:-<unresolved>}"
+echo "  current ${current_ref} → ${current_digest:-<unresolved>}"
+
+{ [ -n "$target_digest" ] && [ -n "$current_digest" ]; } \
+  || emit true "could not resolve a digest"
+
+if [ "$target_digest" = "$current_digest" ]; then
+  emit false "target digest matches the running image"
+else
+  emit true "target digest differs from the running image"
+fi

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,6 +67,21 @@ Run the [**Deploy | Production**](../.github/workflows/deploy-prod.yml) workflow
 It pins every production compose to that version and redeploys. Cut a release,
 let it bake on staging, and ship it to production whenever you choose.
 
+**No-op deploys are skipped.** A release re-tags *every* dokploy project as
+`:vX.Y.Z`, so a project unchanged since the previous release gets a `:vX.Y.Z`
+that points at the **same digest** as what is already running — redeploying it
+would just restart the container (a brief blip) for an identical image. Before
+deploying each project, the workflow compares the target tag's multi-arch index
+digest against the tag the project's Dokploy compose is **currently pinned to**
+(read via `compose.one` — the live, deployed state, so it stays correct even if
+production skipped a release) and **skips** the deploy when they match. Every
+decision is logged with the digests compared — no silent skips. The check is
+fail-safe: a first deploy (no current tag), an unreachable registry, or any
+unresolvable digest falls through to a normal deploy. The promote step is
+untouched — all six projects still get the `:vX.Y.Z` tag — the optimisation
+lives only in the deploy. See
+[`.moon/scripts/dokploy-prod-image-changed.sh`](../.moon/scripts/dokploy-prod-image-changed.sh).
+
 > **Pin production to an explicit `vX.Y.Z`, never to the moving `:stable`/`:latest`
 > alias.** That's what keeps production immutable and reproducible. `:stable` is
 > only a convenience pointer to the most recent release.


### PR DESCRIPTION
## What & why

With **build-once-promote-many**, cutting a release re-tags **every** dokploy project's image as `:vX.Y.Z` — even projects unchanged since the previous release. Their `:vX.Y.Z` just points at the **same digest** as before, so redeploying them in production is a no-op that still **restarts the container** (a brief blip) for an identical image.

This makes **Deploy | Production** redeploy only the projects whose target image actually differs from what's running, and skip the rest.

## How

Per project, before deploying:

- **Target digest** = multi-arch index digest of `…/<project>:<version>` (`docker buildx imagetools inspect --raw`).
- **Current digest** = the tag the project's Dokploy compose is **currently pinned to** (`IMAGE_TAG`, read live via `compose.one`), inspected the same way.
- Equal → **skip** (logged, with both digests); different → deploy.

Source of truth is the compose's live `IMAGE_TAG`, so the decision is correct even if production skipped a release. The logic lives in a small, unit-tested helper: [`.moon/scripts/dokploy-prod-image-changed.sh`](.moon/scripts/dokploy-prod-image-changed.sh).

### Design note — per-leg skip vs. pre-filtering the matrix

The task suggested filtering inside `define-matrix`. That step would need the **production-environment-scoped** Dokploy secrets (`DOKPLOY_API_*`, `<PROJECT>_DOKPLOY_ID`) to read each compose's current tag, which means putting `define-matrix` in the `production` environment — introducing a **second approval gate** per run. Instead, the skip decision is made **inside each `deploy-production` leg**, where that secret context already exists. This fully meets the stated goal (no needless container restarts) without changing the approval UX. Unchanged legs end in a near-instant logged skip.

## Edge cases (all → fail-safe deploy)

- First prod deploy (no current `IMAGE_TAG`) → deploy.
- Unresolvable digest / unreachable registry → deploy.
- Rollback to an older version → digests differ → deploys.

The script always exits `0`, so a transient registry hiccup never fails the deploy — it just deploys.

## Acceptance criteria

- ✅ Deploying a version where only `tera-api` changed redeploys only `tera-api`; the others are **skipped with an explicit log** (notice + the compared digests — no silent skips).
- ✅ Rollback stays functional (older version → different digest → deploys).
- ✅ Promote unchanged — all six projects still get `:vX.Y.Z`; the optimisation is deploy-only.

## Files

- `.github/workflows/deploy-prod.yml` — buildx + GHCR login, resolve compose id, detect-change gate, skip/deploy steps.
- `.moon/scripts/dokploy-prod-image-changed.sh` — digest comparison helper (new).
- `docs/deployment.md` — documents the no-op skip behaviour.

## Testing

`docker`/`curl` were stubbed to exercise the helper: equal digests → `changed=false`; differing → `true`; missing current tag → `true`; unresolvable target/current digest → `true`; `$GITHUB_OUTPUT` written correctly. Workflow YAML validated. (`shellcheck`/`actionlint` aren't available in this environment; `bash -n` passed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8bQS7aDtyeeu16WMP5Prm)_