### PR TITLE
chore(templates): sync php-api scaffold with current API projects

### DIFF
--- a/templates/php-api/Dockerfile
+++ b/templates/php-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:1.9-php8.4 AS frankenphp_upstream
+FROM dunglas/frankenphp:1.12-php8.5 AS frankenphp_upstream
 
 FROM frankenphp_upstream AS frankenphp_base
 
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	gettext \
 	git \
     unzip \
+    librabbitmq-dev \
+    $PHPIZE_DEPS \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
@@ -22,16 +24,31 @@ RUN set -eux; \
 		opcache \
         exif \
 		zip \
-        amqp \
         curl \
+        pdo_pgsql \
 	;
 
-###> recipes ###
-###> doctrine/doctrine-bundle ###
 RUN set -eux; \
-	install-php-extensions pdo_pgsql
-###< doctrine/doctrine-bundle ###
-###< recipes ###
+    git clone https://github.com/php-amqp/php-amqp.git /tmp/php-amqp; \
+    cd /tmp/php-amqp; \
+    phpize; \
+    ./configure; \
+    make -j$(nproc); \
+    make install; \
+    docker-php-ext-enable amqp; \
+    rm -rf /tmp/php-amqp;
+
+# Install the gRPC extension (and its protobuf companion) so the APIs can speak
+# gRPC when needed. grpc and protobuf are very large C/C++ extensions: compiling
+# them with one make job per CPU exhausts memory on multi-core builders, which is
+# the OOM / "memory overflow" failure. Pin install-php-extensions to a single
+# processor so peak memory stays bounded — the build is slower but reliable on
+# any builder.
+RUN set -eux; \
+    IPE_PROCESSOR_COUNT=1 install-php-extensions \
+        grpc \
+        protobuf \
+    ;
 
 ENV PHP_INI_SCAN_DIR=":$PHP_INI_DIR/app.conf.d"
 

--- a/templates/php-api/compose.ci.yml
+++ b/templates/php-api/compose.ci.yml
@@ -1,4 +1,4 @@
-# Development environment override
+# CI environment override
 services:
   database:
     environment:
@@ -14,8 +14,7 @@ services:
     ports:
       - '5432:5432'
 
-  php:
-    build: !reset null
+  api:
     environment:
       - PHP_CS_FIXER_IGNORE_ENV=1
     extra_hosts:

--- a/templates/php-api/compose.override.yml.twig
+++ b/templates/php-api/compose.override.yml.twig
@@ -1,9 +1,9 @@
 # Development environment override
 services:
-  {{ name }}-database:
+  database:
     ports:
       - '21432:5432/tcp' #TODO Change it
-  {{ name }}-api:
+  api:
     build:
       context: .
       target: frankenphp_dev

--- a/templates/php-api/compose.yml.twig
+++ b/templates/php-api/compose.yml.twig
@@ -1,7 +1,5 @@
-name: {{ name }}-api
-
 services:
-  {{ name }}-database:
+  database:
     environment:
       - POSTGRES_DB=${POSTGRES_DB:-app}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-PasswordForLocal!}
@@ -13,33 +11,58 @@ services:
       timeout: 5s
     image: postgres:${POSTGRES_VERSION:-16}-alpine
     volumes:
-      - {{ name }}_database_data:/var/lib/postgresql/data:rw
+      - database_data:/var/lib/postgresql/data:rw
 
-  {{ name }}-api:
+  api:
     depends_on:
-      {{ name }}-database:
+      database:
         condition: service_healthy
+      rabbitmq:
+        condition: service_started
+      redis:
+        condition: service_started
     environment:
-      # Run "composer require symfony/mercure-bundle" to install and configure the Mercure integration
-      #MERCURE_URL: ${CADDY_MERCURE_URL:-http://php/.well-known/mercure}
-      #MERCURE_PUBLIC_URL: ${CADDY_MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}/.well-known/mercure}
-      #MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       APP_RUNTIME: Runtime\FrankenPhpSymfony\Runtime
-      # Run "composer require symfony/orm-pack" to install and configure Doctrine ORM
-      DATABASE_URL: postgresql://${POSTGRES_USER:-userlocal}:${POSTGRES_PASSWORD:-PasswordForLocal!}@{{ name }}-database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-16}&charset=${POSTGRES_CHARSET:-utf8}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-userlocal}:${POSTGRES_PASSWORD:-PasswordForLocal!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-16}&charset=${POSTGRES_CHARSET:-utf8}
+      MESSENGER_TRANSPORT_DSN: amqp://app:app@rabbitmq:5672/app
+      REDIS_URL: redis://redis:6379
       SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
       TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-example\.com|localhost}|php$$}
-      #MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
-      #MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}
-    image: ${IMAGES_PREFIX:-}{{ name }}-api
+    image: ${IMAGES_PREFIX:-}{{ name }}-api:${IMAGE_TAG:-latest}
     restart: unless-stopped
     volumes:
-      - {{ name }}_caddy_data:/data
-      - {{ name }}_caddy_config:/config
+      - caddy_data:/data
+      - caddy_config:/config
       - ../../../libs/php:/packages
 
+  redis:
+    healthcheck:
+      retries: 5
+      start_period: 10s
+      test: ['CMD', 'redis-cli', 'ping']
+      timeout: 3s
+    image: redis:alpine
+    volumes:
+      - redis_data:/data
+
+  rabbitmq:
+    environment:
+      - RABBITMQ_DEFAULT_USER=app
+      - RABBITMQ_DEFAULT_PASS=app
+      - RABBITMQ_DEFAULT_VHOST=app
+    healthcheck:
+      retries: 5
+      start_period: 30s
+      test: ['CMD', 'rabbitmq-diagnostics', '-q', 'ping']
+      timeout: 10s
+    image: rabbitmq:4.0.4-management-alpine
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq/
+
 volumes:
-  {{ name }}_caddy_config:
-  {{ name }}_caddy_data:
-  {{ name }}_database_data:
+  caddy_config:
+  caddy_data:
+  database_data:
+  rabbitmq_data:
+  redis_data:


### PR DESCRIPTION
## Summary

The `templates/php-api` scaffold had drifted from the real API projects. The `tera`, `espace`, and `flora` APIs have since converged on an **identical** container/orchestration setup (byte-for-byte identical Dockerfiles, same compose service layout), while the template still reflected an older Symfony Flex baseline. This brings the template back in line so a newly scaffolded API matches what the existing projects actually look like today.

## What changed

**`Dockerfile`**
- FrankenPHP `1.12` / PHP `8.5` (was `1.9` / `8.4`)
- Build the `amqp` extension from source (`librabbitmq-dev` + `$PHPIZE_DEPS`) instead of via `install-php-extensions amqp`
- Add the `grpc` + `protobuf` extensions with the `IPE_PROCESSOR_COUNT=1` OOM guard (matching the projects' comment explaining the memory-overflow failure on multi-core builders)
- Fold `pdo_pgsql` into the main `install-php-extensions` block (dropping the stale `###> recipes ###` doctrine recipe markers)

**`compose.yml.twig`**
- Add the `redis` and `rabbitmq` services (and their volumes) that every API now depends on
- Wire `MESSENGER_TRANSPORT_DSN` and `REDIS_URL`, and add `depends_on` for both
- Tag the image with `${IMAGE_TAG:-latest}`
- Drop the obsolete commented Mercure boilerplate

**`compose.yml.twig` / `compose.override.yml.twig` / `compose.ci.yml`**
- Align service names with the projects (`database` / `api`, no `{{ name }}-`prefixed services and no top-level `name:`)
- Fix the CI override's mislabelled `# Development environment override` comment → `# CI environment override`, and drop the now-unnecessary `build: !reset null`

## Verification & scope notes

- The new `Dockerfile` is identical to the (matching) `tera`/`espace`/`flora` `api/Dockerfile`s, which are byte-for-byte identical to each other — there is one clear canonical pattern to track.
- `redis` + `rabbitmq` are present in **all three** API projects (including the API-only `flora`), so adding them to the template is faithful to the common convention rather than a project-specific choice.
- The `frankenphp/*` config files (Caddyfile, conf.d, docker-entrypoint, worker.Caddyfile) already match the projects — no change needed.
- Deliberately left out: `Kernel.php` (projects import `*.php` config; the template is internally consistent on `*.yml` and changing it would break scaffolding), `bootstrap.php` (cosmetic whitespace-only drift), and `.gitignore`'s `root.crt` entry (espace-only, not a shared convention).

This change touches scaffolding only — it does not affect any running service or CI pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019q62PnriRVMN3x238ziA4e

---
_Generated by [Claude Code](https://claude.ai/code/session_019q62PnriRVMN3x238ziA4e)_