### PR TITLE
chore(espace): POC Temporal orchestration for the AreaProposal lifecycle

### DIFF
--- a/projects/espace/api/poc/temporal/.gitignore
+++ b/projects/espace/api/poc/temporal/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+/rr
+/.rr.pid
+composer.lock

--- a/projects/espace/api/poc/temporal/.rr.yml
+++ b/projects/espace/api/poc/temporal/.rr.yml
@@ -1,0 +1,20 @@
+# RoadRunner configuration for the Temporal PHP worker.
+# RoadRunner hosts the long-running PHP processes that Temporal streams
+# workflow and activity tasks to. Start it with: rr serve -c .rr.yml
+version: "3"
+
+rpc:
+  listen: tcp://127.0.0.1:6001
+
+server:
+  command: "php worker.php"
+
+temporal:
+  address: ${TEMPORAL_ADDRESS:-temporal:7233}
+  activities:
+    num_workers: 4
+    max_jobs: 64
+
+logs:
+  level: info
+  mode: production

--- a/projects/espace/api/poc/temporal/ANALYSIS.md
+++ b/projects/espace/api/poc/temporal/ANALYSIS.md
@@ -1,0 +1,148 @@
+# Analyse : Temporal vs Symfony Workflow pour les workflows des APIs
+
+> Contexte : POC demandé sur l'API **espace**, en prenant le cycle de vie d'une
+> `AreaProposal` (_landProposal_) comme cas réel. Objectif : déterminer si
+> remplacer le composant **Symfony Workflow** par **Temporal** est pertinent.
+
+## TL;DR — Recommandation
+
+**Ne pas migrer les workflows existants vers Temporal aujourd'hui.** Le composant
+Symfony Workflow couvre parfaitement le besoin actuel (machines à états courtes,
+pilotées par des requêtes HTTP). Temporal résout une catégorie de problèmes que
+Lychen **n'a pas encore** : orchestrations longues, multi-étapes, avec attentes,
+timers et appels externes non fiables.
+
+➡️ **Garder Symfony Workflow** pour les transitions de statut métier
+(`AreaProposal`, `AreaRequest`, etc.).
+
+➡️ **Réévaluer Temporal le jour où** apparaît un vrai processus distribué et
+durable (ex. : cycle complet d'une mise en relation `landRequest ↔ landProposal`
+avec relances, délais d'expiration, paiement, contractualisation, jobs externes).
+Le POC de ce dossier est la base de cette réévaluation.
+
+---
+
+## Ce que fait chaque outil
+
+### Symfony Workflow (l'existant)
+
+`config/packages/workflow/workflow.php` définit la machine à états
+`area_proposal_publishing` :
+
+```
+draft ──submit──▶ verification ──publish──▶ published ──archive──▶ archived
+                  verification ──reject───▶ draft
+```
+
+C'est un **ensemble de règles** : « depuis quelle place puis-je aller vers
+quelle place ». Le composant :
+
+- valide qu'une transition est autorisée (`can()` / `apply()`) ;
+- déplace une propriété de l'entité (`place`) ;
+- déclenche des événements (`workflow.*`) sur lesquels on branche des listeners ;
+- fournit un audit trail en mémoire.
+
+L'état vit **dans la base** (colonne `place`). Le « moteur » n'est qu'une
+validation appliquée pendant une requête HTTP, puis il disparaît. C'est simple,
+synchrone, testable, sans aucune infrastructure.
+
+### Temporal (le POC)
+
+Temporal est un **moteur d'orchestration durable**. Le workflow est du code PHP
+qui **s'exécute dans la durée** : il peut attendre des heures ou des mois, dormir,
+réagir à des signaux, appeler des « activités » (effets de bord) et **survivre aux
+redéploiements et aux crashs** car Temporal rejoue l'historique d'événements pour
+reconstruire l'état exact.
+
+Dans le POC (`src/AreaProposalWorkflow.php`) :
+
+- la table de transitions est identique à la version Symfony ;
+- chaque transition déclenche des **activités retentées automatiquement**
+  (persistance, notifications, indexation SEO) ;
+- un **timer durable** auto-archive une proposition publiée depuis trop longtemps,
+  sans cron ni Messenger.
+
+---
+
+## Comparaison
+
+| Critère | Symfony Workflow | Temporal |
+| --- | --- | --- |
+| **Nature** | Validation de transitions, synchrone | Orchestration durable, asynchrone |
+| **Où vit l'état** | Colonne en base (`place`) | Historique d'événements Temporal (+ projection en base via activités) |
+| **Processus longs / attentes** | ❌ Non (il faut cron + Messenger + colonnes de suivi) | ✅ Natif (`await`, timers durables de plusieurs mois) |
+| **Reprise après crash / redeploy** | N/A (rien ne tourne) | ✅ Garantie, rejeu déterministe |
+| **Retry des effets de bord** | À coder à la main (Messenger retry) | ✅ Intégré, configurable (backoff, max attempts) |
+| **Unicité d'exécution** | À gérer soi-même | ✅ `WorkflowId` unique imposé par Temporal |
+| **Visibilité / debug** | Audit trail mémoire + logs | ✅ UI dédiée : historique complet, état, replay |
+| **Tests** | Unitaires triviaux, aucun service | SDK de test + worker ; plus lourd |
+| **Infrastructure** | **Aucune** (déjà dans Symfony) | **Lourde** : serveur Temporal + sa base, **RoadRunner**, extensions `grpc`/`protobuf` |
+| **Runtime** | FrankenPHP (déjà en place) | RoadRunner en **plus** de FrankenPHP (2e runtime PHP à opérer) |
+| **Langage** | PHP/Symfony idiomatique | PHP via SDK + contraintes de **déterminisme** dans le workflow |
+| **Courbe d'apprentissage** | Faible (connu de l'équipe) | Élevée (déterminisme, signals/queries, versioning) |
+| **Coût opérationnel** | ~0 | Cluster à héberger, monitorer, mettre à jour |
+
+---
+
+## Le point structurant : le runtime
+
+L'API tourne sur **FrankenPHP** (`APP_RUNTIME: Runtime\FrankenPhpSymfony\Runtime`).
+Le SDK PHP de Temporal impose **RoadRunner** comme hôte des workers (workflows et
+activités s'exécutent dans des process RoadRunner pilotés en gRPC).
+
+Adopter Temporal signifie donc faire **cohabiter deux runtimes PHP** (FrankenPHP
+pour l'API HTTP, RoadRunner pour les workers Temporal), plus le cluster Temporal
+et sa base. Pour la valeur apportée au besoin **actuel** (de simples transitions
+de statut), ce surcoût d'exploitation n'est pas justifié.
+
+À noter : Lychen possède **déjà RabbitMQ + Symfony Messenger**. Une bonne partie
+de ce qu'on irait chercher dans Temporal à court terme (retry d'effets de bord,
+traitement asynchrone) est **déjà disponible** avec la stack en place.
+
+---
+
+## Quand Temporal deviendrait le bon choix
+
+Le besoin exprimé dans la tâche — « un workflow **complet** pour une landRequest
+ou landProposal » — est précisément le terrain où Temporal brille **si** ce
+workflow devient réellement long et distribué, par exemple :
+
+1. une `AreaRequest` est ouverte ;
+2. on attend des `AreaProposal` correspondantes (attente de plusieurs jours) ;
+3. relances automatiques au demandeur / aux propriétaires (timers) ;
+4. étape de vérification humaine (signal externe, possiblement après des semaines) ;
+5. mise en relation, voire contractualisation / paiement via services externes
+   (appels faillibles → retry) ;
+6. expiration automatique si rien n'aboutit (timer durable).
+
+Un tel processus, écrit « à la main » avec Symfony Workflow + cron + Messenger +
+colonnes de suivi, devient vite fragile et difficile à observer. C'est exactement
+ce que Temporal industrialise. **Tant que ce processus n'existe pas**, Temporal
+est une solution sans problème à résoudre.
+
+### Critères de décision (checklist)
+
+Migrer/adopter Temporal devient pertinent dès que **plusieurs** de ces points sont vrais :
+
+- [ ] Le processus s'étale sur **heures/jours/mois**, pas sur une requête HTTP.
+- [ ] Il enchaîne **plusieurs appels externes faillibles** nécessitant retry/compensation.
+- [ ] Il faut des **timers durables** (expirations, relances) fiables.
+- [ ] La **reprise après crash** au milieu du processus est critique.
+- [ ] Le besoin de **visibilité/audit** dépasse ce que donnent les logs.
+- [ ] Le **coût d'exploitation** d'un cluster Temporal est acceptable pour l'équipe.
+
+Aujourd'hui sur espace : **aucun** de ces points n'est rempli pour
+`AreaProposal`. → Symfony Workflow reste le bon outil.
+
+---
+
+## Conclusion
+
+| Question | Réponse |
+| --- | --- |
+| Est-ce techniquement possible ? | **Oui** — le POC reproduit fidèlement la machine à états et ajoute retries + timer durable. |
+| Est-ce « mieux » pour le besoin actuel ? | **Non** — surcoût d'infrastructure et de runtime (RoadRunner + cluster) disproportionné face à de simples transitions de statut. |
+| Faut-il jeter l'idée ? | **Non** — garder ce POC comme socle ; réévaluer dès qu'un workflow réellement long/distribué (mise en relation landRequest ↔ landProposal de bout en bout) sera au programme. |
+
+**Décision recommandée : statu quo (Symfony Workflow), avec Temporal en option
+documentée pour les futurs processus longue durée.**

--- a/projects/espace/api/poc/temporal/Dockerfile
+++ b/projects/espace/api/poc/temporal/Dockerfile
@@ -1,0 +1,18 @@
+# Minimal PHP + RoadRunner image hosting the Temporal worker.
+FROM php:8.4-cli-alpine
+
+RUN apk add --no-cache $PHPIZE_DEPS linux-headers protobuf-dev \
+    && pecl install grpc protobuf \
+    && docker-php-ext-enable grpc protobuf \
+    && apk del $PHPIZE_DEPS
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+COPY composer.json ./
+RUN composer install --no-interaction --no-dev --prefer-dist \
+    && vendor/bin/rr get-binary --location /usr/local/bin
+
+COPY . .
+
+CMD ["rr", "serve", "-c", ".rr.yml"]

--- a/projects/espace/api/poc/temporal/README.md
+++ b/projects/espace/api/poc/temporal/README.md
@@ -1,0 +1,84 @@
+# POC — Temporal workflows for the espace API
+
+This is a **proof of concept** that re-implements the espace `AreaProposal`
+(_landProposal_) publishing lifecycle with [Temporal](https://temporal.io/)
+instead of the Symfony Workflow component, so the two can be compared.
+
+> See [`ANALYSIS.md`](./ANALYSIS.md) for the full Symfony Workflow vs Temporal
+> comparison and the recommendation.
+
+It is deliberately **isolated** from the api project: its own `composer.json`,
+its own `compose.yml`, no autowiring into `src/`. Nothing here is built or
+linted by the espace-api Moon tasks (phpstan/rector only scan `src/` & `tests/`).
+
+## What it models
+
+The exact same state machine as
+`src/Workflow/AreaProposal/AreaProposalWorkflow.php`:
+
+```
+draft ──submit──▶ verification ──publish──▶ published ──archive──▶ archived
+                  verification ──reject───▶ draft
+                  verification ──archive──▶ archived
+```
+
+Two things go beyond the Symfony version on purpose, to show what Temporal buys
+you:
+
+1. **Activities with automatic retries** — every side effect (DB write,
+   moderator/author notifications, SEO (de)indexing) is a Temporal Activity,
+   retried on failure with backoff.
+2. **A durable timer** — a `published` proposal is auto-archived after a TTL
+   (`P180D`) without any cron or Messenger scheduler.
+
+## Layout
+
+| File | Role |
+| --- | --- |
+| `src/AreaProposalWorkflowInterface.php` | Workflow contract (signals + queries) |
+| `src/AreaProposalWorkflow.php` | Durable orchestration of the lifecycle |
+| `src/AreaProposalActivitiesInterface.php` | Side-effect contract |
+| `src/AreaProposalActivities.php` | POC implementation (logs only) |
+| `worker.php` | RoadRunner worker host |
+| `bin/start_workflow.php` | Client: start an execution |
+| `bin/signal_workflow.php` | Client: drive it (submit/publish/…) + read state |
+| `.rr.yml` | RoadRunner config |
+| `compose.yml` / `Dockerfile` | Temporal server + UI + worker |
+
+## Running it
+
+> Requires Docker. The PHP Temporal SDK needs the `grpc` + `protobuf`
+> extensions and RoadRunner; the provided `Dockerfile` bundles all of it.
+
+```bash
+# 1. Temporal server + web UI (http://localhost:8233)
+docker compose up -d temporal temporal-ui
+
+# 2. The worker (PHP + RoadRunner)
+docker compose up worker         # or, locally: composer install && composer worker
+
+# 3. Drive a proposal through its lifecycle
+php bin/start_workflow.php demo-1
+php bin/signal_workflow.php demo-1 submit
+php bin/signal_workflow.php demo-1 publish
+php bin/signal_workflow.php demo-1 archive   # -> reaches the terminal place
+```
+
+Each command prints the current `place` and the transition history (also
+visible, with full event history, in the Temporal UI).
+
+## Wiring it to the real API
+
+The activity bodies in `AreaProposalActivities.php` only log. To make this
+production-real, inject the espace services and replace the bodies, e.g.:
+
+```php
+public function persistPlace(string $uuid, string $place): void
+{
+    $proposal = $this->repository->findOneByUuid($uuid);
+    $proposal->setPlace($place);
+    $this->em->flush();
+}
+```
+
+The workflow code itself would not change.

--- a/projects/espace/api/poc/temporal/bin/signal_workflow.php
+++ b/projects/espace/api/poc/temporal/bin/signal_workflow.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Poc\Temporal\AreaProposalWorkflowInterface;
+use Temporal\Client\GRPC\ServiceClient;
+use Temporal\Client\WorkflowClient;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+/**
+ * Sends a transition signal to a running AreaProposal workflow and prints its
+ * current place.
+ *
+ * Usage:
+ *   php bin/signal_workflow.php <areaProposalUuid> <submit|publish|reject|archive|status> [reason]
+ */
+$uuid = $argv[1] ?? null;
+$action = $argv[2] ?? 'status';
+$reason = $argv[3] ?? '';
+$address = getenv('TEMPORAL_ADDRESS') ?: 'localhost:7233';
+
+if (null === $uuid) {
+    fwrite(\STDERR, "Missing AreaProposal UUID.\n");
+    exit(1);
+}
+
+$client = WorkflowClient::create(ServiceClient::create($address));
+
+/** @var AreaProposalWorkflowInterface $workflow */
+$workflow = $client->newRunningWorkflowStub(
+    AreaProposalWorkflowInterface::class,
+    'area-proposal-' . $uuid,
+);
+
+switch ($action) {
+    case 'submit':
+        $workflow->submit();
+        break;
+    case 'publish':
+        $workflow->publish();
+        break;
+    case 'reject':
+        $workflow->reject($reason);
+        break;
+    case 'archive':
+        $workflow->archive();
+        break;
+    case 'status':
+        break;
+    default:
+        fwrite(\STDERR, sprintf("Unknown action \"%s\".\n", $action));
+        exit(1);
+}
+
+// Queries are read-only and always reflect the latest workflow state.
+echo sprintf("Place:   %s\n", $workflow->getPlace());
+echo sprintf("History: %s\n", json_encode($workflow->getHistory(), \JSON_PRETTY_PRINT));

--- a/projects/espace/api/poc/temporal/bin/start_workflow.php
+++ b/projects/espace/api/poc/temporal/bin/start_workflow.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Poc\Temporal\AreaProposalWorkflowInterface;
+use Temporal\Client\GRPC\ServiceClient;
+use Temporal\Client\WorkflowClient;
+use Temporal\Client\WorkflowOptions;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+/**
+ * Starts one AreaProposal workflow execution.
+ *
+ * Usage:
+ *   php bin/start_workflow.php [areaProposalUuid] [temporalAddress]
+ *
+ * The WorkflowId is derived from the UUID so the same proposal can never have
+ * two concurrent executions (Temporal rejects duplicate WorkflowIds) — a
+ * uniqueness guarantee the Symfony component does not give you.
+ */
+$uuid = $argv[1] ?? bin2hex(random_bytes(8));
+$address = $argv[2] ?? (getenv('TEMPORAL_ADDRESS') ?: 'localhost:7233');
+
+$client = WorkflowClient::create(ServiceClient::create($address));
+
+$workflow = $client->newWorkflowStub(
+    AreaProposalWorkflowInterface::class,
+    WorkflowOptions::new()
+        ->withTaskQueue('espace.area_proposal')
+        ->withWorkflowId('area-proposal-' . $uuid),
+);
+
+$run = $client->start($workflow, $uuid);
+
+echo sprintf("Started workflow for AreaProposal %s\n", $uuid);
+echo sprintf("  WorkflowId: %s\n", $run->getExecution()->getID());
+echo sprintf("  RunId:      %s\n", $run->getExecution()->getRunID());
+echo "\nDrive it with:\n";
+echo sprintf("  php bin/signal_workflow.php %s submit\n", $uuid);
+echo sprintf("  php bin/signal_workflow.php %s publish\n", $uuid);
+echo sprintf("  php bin/signal_workflow.php %s archive\n", $uuid);

--- a/projects/espace/api/poc/temporal/compose.yml
+++ b/projects/espace/api/poc/temporal/compose.yml
@@ -1,0 +1,48 @@
+# Self-contained Temporal stack for the POC.
+#   docker compose up -d        # Temporal server + UI + Postgres
+#   docker compose up worker    # the PHP/RoadRunner worker
+# Temporal UI: http://localhost:8233
+services:
+    temporal-postgres:
+        image: postgres:16-alpine
+        environment:
+            - POSTGRES_USER=temporal
+            - POSTGRES_PASSWORD=temporal
+        volumes:
+            - temporal_pg:/var/lib/postgresql/data:rw
+
+    temporal:
+        image: temporalio/auto-setup:1.25.2
+        depends_on:
+            - temporal-postgres
+        environment:
+            - DB=postgres12
+            - DB_PORT=5432
+            - POSTGRES_USER=temporal
+            - POSTGRES_PWD=temporal
+            - POSTGRES_SEEDS=temporal-postgres
+        ports:
+            - "7233:7233"
+
+    temporal-ui:
+        image: temporalio/ui:2.31.2
+        depends_on:
+            - temporal
+        environment:
+            - TEMPORAL_ADDRESS=temporal:7233
+            - TEMPORAL_CORS_ORIGINS=http://localhost:8233
+        ports:
+            - "8233:8080"
+
+    worker:
+        build:
+            context: .
+            dockerfile: Dockerfile
+        depends_on:
+            - temporal
+        environment:
+            - TEMPORAL_ADDRESS=temporal:7233
+        restart: unless-stopped
+
+volumes:
+    temporal_pg:

--- a/projects/espace/api/poc/temporal/composer.json
+++ b/projects/espace/api/poc/temporal/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "lychen/espace-api-poc-temporal",
+    "description": "Proof of concept: orchestrating the espace AreaProposal (landProposal) lifecycle with Temporal instead of the Symfony Workflow component.",
+    "type": "project",
+    "license": "proprietary",
+    "require": {
+        "php": ">=8.4",
+        "ext-grpc": "*",
+        "ext-protobuf": "*",
+        "spiral/roadrunner-cli": "^2.6",
+        "temporal/sdk": "^2.12"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\Poc\\Temporal\\": "src/"
+        }
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "spiral/roadrunner-cli": true
+        }
+    },
+    "scripts": {
+        "rr:get": "rr get-binary",
+        "worker": "rr serve -c .rr.yml",
+        "start": "php bin/start_workflow.php",
+        "drive": "php bin/signal_workflow.php"
+    }
+}

--- a/projects/espace/api/poc/temporal/src/AreaProposalActivities.php
+++ b/projects/espace/api/poc/temporal/src/AreaProposalActivities.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Poc\Temporal;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * POC implementation of the activities: it only logs what it would do.
+ *
+ * In the espace API these methods would be plain Symfony services, autowired
+ * with the EntityManager, MessageBus, etc. Replacing the bodies below with real
+ * calls is all that stands between this POC and a production integration:
+ *
+ *   public function persistPlace(string $uuid, string $place): void
+ *   {
+ *       $proposal = $this->repository->findOneByUuid($uuid);
+ *       $proposal->setPlace($place);
+ *       $this->em->flush();
+ *   }
+ */
+final class AreaProposalActivities implements AreaProposalActivitiesInterface
+{
+    public function __construct(
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function persistPlace(string $uuid, string $place): void
+    {
+        $this->log($uuid, sprintf('persist place = %s', $place));
+    }
+
+    public function onEnterPlace(string $uuid, string $place): void
+    {
+        $this->log($uuid, sprintf('entered place "%s"', $place));
+    }
+
+    public function onLeavePlace(string $uuid, string $place, string $transition): void
+    {
+        $this->log($uuid, sprintf('leaving place "%s" via transition "%s"', $place, $transition));
+    }
+
+    public function onBlockedTransition(string $uuid, string $place, string $transition): void
+    {
+        $this->log($uuid, sprintf('transition "%s" not allowed from place "%s" — ignored', $transition, $place));
+    }
+
+    public function notifyModerators(string $uuid): void
+    {
+        $this->log($uuid, 'notify moderators: a proposal is awaiting verification');
+    }
+
+    public function notifyAuthor(string $uuid, string $message): void
+    {
+        $this->log($uuid, sprintf('notify author: %s', $message));
+    }
+
+    public function indexForSeo(string $uuid): void
+    {
+        $this->log($uuid, 'index proposal for SEO');
+    }
+
+    public function removeFromSeoIndex(string $uuid): void
+    {
+        $this->log($uuid, 'remove proposal from SEO index');
+    }
+
+    private function log(string $uuid, string $message): void
+    {
+        $line = sprintf('[AreaProposal %s] %s', $uuid, $message);
+        $this->logger->info($line);
+        fwrite(\STDERR, $line . \PHP_EOL);
+    }
+}

--- a/projects/espace/api/poc/temporal/src/AreaProposalActivitiesInterface.php
+++ b/projects/espace/api/poc/temporal/src/AreaProposalActivitiesInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Poc\Temporal;
+
+use Temporal\Activity\ActivityInterface;
+use Temporal\Activity\ActivityMethod;
+
+/**
+ * Side effects executed by the workflow. In a real integration each method
+ * would call the espace API / Doctrine (e.g. update AreaProposal.place, push a
+ * notification through Symfony Messenger, (de)index for SEO). Temporal runs
+ * them outside the workflow's deterministic context and retries them on
+ * failure according to the RetryOptions configured on the stub.
+ */
+#[ActivityInterface(prefix: 'espace.AreaProposal.')]
+interface AreaProposalActivitiesInterface
+{
+    /** Persist the new place on the AreaProposal entity (the DB write). */
+    #[ActivityMethod]
+    public function persistPlace(string $uuid, string $place): void;
+
+    #[ActivityMethod]
+    public function onEnterPlace(string $uuid, string $place): void;
+
+    #[ActivityMethod]
+    public function onLeavePlace(string $uuid, string $place, string $transition): void;
+
+    #[ActivityMethod]
+    public function onBlockedTransition(string $uuid, string $place, string $transition): void;
+
+    #[ActivityMethod]
+    public function notifyModerators(string $uuid): void;
+
+    #[ActivityMethod]
+    public function notifyAuthor(string $uuid, string $message): void;
+
+    #[ActivityMethod]
+    public function indexForSeo(string $uuid): void;
+
+    #[ActivityMethod]
+    public function removeFromSeoIndex(string $uuid): void;
+}

--- a/projects/espace/api/poc/temporal/src/AreaProposalWorkflow.php
+++ b/projects/espace/api/poc/temporal/src/AreaProposalWorkflow.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Poc\Temporal;
+
+use Carbon\CarbonInterval;
+use Temporal\Activity\ActivityOptions;
+use Temporal\Common\RetryOptions;
+use Temporal\Workflow;
+
+/**
+ * Durable implementation of the AreaProposal publishing lifecycle.
+ *
+ * The state machine is intentionally identical to the Symfony one so the two
+ * approaches can be compared on equal footing:
+ *
+ *   draft --submit--> verification --publish--> published --archive--> archived
+ *                     verification --reject--> draft
+ *                     verification --archive--> archived
+ *
+ * Differences with the Symfony component:
+ *  - The transition table is enforced *here*, in code that survives restarts.
+ *  - Each transition triggers Activities (side effects: DB write, notification,
+ *    SEO indexing) that Temporal retries automatically on failure.
+ *  - A durable timer auto-archives a proposal that stays published for too long
+ *    — something that would otherwise require a cron/messenger scheduler.
+ */
+final class AreaProposalWorkflow implements AreaProposalWorkflowInterface
+{
+    public const string PLACE_DRAFT = 'draft';
+    public const string PLACE_VERIFICATION = 'verification';
+    public const string PLACE_PUBLISHED = 'published';
+    public const string PLACE_ARCHIVED = 'archived';
+
+    public const string TRANSITION_SUBMIT = 'submit';
+    public const string TRANSITION_PUBLISH = 'publish';
+    public const string TRANSITION_REJECT = 'reject';
+    public const string TRANSITION_ARCHIVE = 'archive';
+
+    /**
+     * Transition table: [transition => [from-places => to-place]].
+     * Mirrors config/packages/workflow/workflow.php.
+     *
+     * @var array<string, array{from: list<string>, to: string}>
+     */
+    private const array TRANSITIONS = [
+        self::TRANSITION_SUBMIT => [
+            'from' => [self::PLACE_DRAFT],
+            'to' => self::PLACE_VERIFICATION,
+        ],
+        self::TRANSITION_PUBLISH => [
+            'from' => [self::PLACE_VERIFICATION],
+            'to' => self::PLACE_PUBLISHED,
+        ],
+        self::TRANSITION_REJECT => [
+            'from' => [self::PLACE_VERIFICATION],
+            'to' => self::PLACE_DRAFT,
+        ],
+        self::TRANSITION_ARCHIVE => [
+            'from' => [self::PLACE_VERIFICATION, self::PLACE_PUBLISHED],
+            'to' => self::PLACE_ARCHIVED,
+        ],
+    ];
+
+    /**
+     * How long a proposal may stay in `published` before it is archived
+     * automatically. Demonstrates Temporal durable timers.
+     */
+    private const string PUBLISHED_TTL = 'P180D';
+
+    private string $place = self::PLACE_DRAFT;
+
+    private ?string $requestedTransition = null;
+
+    private string $rejectReason = '';
+
+    /** @var list<array{transition: string, from: string, to: string}> */
+    private array $history = [];
+
+    private readonly AreaProposalActivitiesInterface $activities;
+
+    public function __construct()
+    {
+        $this->activities = Workflow::newActivityStub(
+            AreaProposalActivitiesInterface::class,
+            ActivityOptions::new()
+                ->withStartToCloseTimeout(CarbonInterval::seconds(30))
+                ->withRetryOptions(
+                    RetryOptions::new()
+                        ->withInitialInterval(CarbonInterval::seconds(1))
+                        ->withMaximumAttempts(5),
+                ),
+        );
+    }
+
+    public function run(string $areaProposalUuid): \Generator
+    {
+        yield $this->activities->onEnterPlace($areaProposalUuid, self::PLACE_DRAFT);
+
+        while (self::PLACE_ARCHIVED !== $this->place) {
+            $timedOut = false;
+
+            if (self::PLACE_PUBLISHED === $this->place) {
+                // Published proposals wait for an explicit `archive` signal, but
+                // are auto-archived once the TTL elapses (durable timer).
+                $timedOut = !(yield Workflow::awaitWithTimeout(
+                    CarbonInterval::fromString(self::PUBLISHED_TTL),
+                    fn (): bool => null !== $this->requestedTransition,
+                ));
+            } else {
+                yield Workflow::await(fn (): bool => null !== $this->requestedTransition);
+            }
+
+            $transition = $timedOut ? self::TRANSITION_ARCHIVE : (string) $this->requestedTransition;
+            $this->requestedTransition = null;
+
+            if (!$this->canApply($transition)) {
+                // Mirrors Symfony's "transition not enabled" — ignored, the
+                // workflow keeps waiting for a valid signal.
+                yield $this->activities->onBlockedTransition($areaProposalUuid, $this->place, $transition);
+
+                continue;
+            }
+
+            yield from $this->applyTransition($areaProposalUuid, $transition);
+        }
+
+        return $this->place;
+    }
+
+    private function canApply(string $transition): bool
+    {
+        return isset(self::TRANSITIONS[$transition])
+            && \in_array($this->place, self::TRANSITIONS[$transition]['from'], true);
+    }
+
+    private function applyTransition(string $uuid, string $transition): \Generator
+    {
+        $from = $this->place;
+        $to = self::TRANSITIONS[$transition]['to'];
+
+        yield $this->activities->onLeavePlace($uuid, $from, $transition);
+
+        $this->place = $to;
+        $this->history[] = ['transition' => $transition, 'from' => $from, 'to' => $to];
+
+        // Per-transition side effects, each one a retried Activity.
+        switch ($transition) {
+            case self::TRANSITION_SUBMIT:
+                yield $this->activities->notifyModerators($uuid);
+                break;
+            case self::TRANSITION_PUBLISH:
+                yield $this->activities->indexForSeo($uuid);
+                yield $this->activities->notifyAuthor($uuid, 'published');
+                break;
+            case self::TRANSITION_REJECT:
+                yield $this->activities->notifyAuthor($uuid, 'rejected: ' . $this->rejectReason);
+                break;
+            case self::TRANSITION_ARCHIVE:
+                yield $this->activities->removeFromSeoIndex($uuid);
+                break;
+        }
+
+        yield $this->activities->persistPlace($uuid, $to);
+        yield $this->activities->onEnterPlace($uuid, $to);
+    }
+
+    public function submit(): void
+    {
+        $this->requestedTransition = self::TRANSITION_SUBMIT;
+    }
+
+    public function publish(): void
+    {
+        $this->requestedTransition = self::TRANSITION_PUBLISH;
+    }
+
+    public function reject(string $reason = ''): void
+    {
+        $this->rejectReason = $reason;
+        $this->requestedTransition = self::TRANSITION_REJECT;
+    }
+
+    public function archive(): void
+    {
+        $this->requestedTransition = self::TRANSITION_ARCHIVE;
+    }
+
+    public function getPlace(): string
+    {
+        return $this->place;
+    }
+
+    public function getHistory(): array
+    {
+        return $this->history;
+    }
+}

--- a/projects/espace/api/poc/temporal/src/AreaProposalWorkflowInterface.php
+++ b/projects/espace/api/poc/temporal/src/AreaProposalWorkflowInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Poc\Temporal;
+
+use Temporal\Workflow\QueryMethod;
+use Temporal\Workflow\SignalMethod;
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+/**
+ * Temporal counterpart of the Symfony state machine
+ * `App\Workflow\AreaProposal\AreaProposalWorkflow` (state machine
+ * `area_proposal_publishing`).
+ *
+ * Places:      draft -> verification -> published -> archived
+ * Transitions: submit, publish, reject, archive
+ *
+ * Where the Symfony component is a passive set of rules applied synchronously
+ * inside an HTTP request, the Temporal workflow is a long-lived, durable
+ * orchestration: it is started once for a given AreaProposal and then driven
+ * by signals (submit / publish / reject / archive) until it reaches a final
+ * place. The current place is exposed through a query so the API can read it
+ * without touching the database.
+ */
+#[WorkflowInterface]
+interface AreaProposalWorkflowInterface
+{
+    /**
+     * Runs the full publishing lifecycle of an AreaProposal until it is
+     * archived (the only terminal place).
+     *
+     * @param string $areaProposalUuid the UUID of the AreaProposal entity
+     *
+     * @return string the final place reached by the proposal
+     */
+    #[WorkflowMethod(name: 'espace.AreaProposalWorkflow')]
+    public function run(string $areaProposalUuid): \Generator;
+
+    /** draft -> verification */
+    #[SignalMethod]
+    public function submit(): void;
+
+    /** verification -> published */
+    #[SignalMethod]
+    public function publish(): void;
+
+    /** verification -> draft */
+    #[SignalMethod]
+    public function reject(string $reason = ''): void;
+
+    /** verification|published -> archived */
+    #[SignalMethod]
+    public function archive(): void;
+
+    /** Current place of the proposal (draft|verification|published|archived). */
+    #[QueryMethod]
+    public function getPlace(): string;
+
+    /**
+     * Ordered audit trail of the transitions applied so far.
+     *
+     * @return list<array{transition: string, from: string, to: string}>
+     */
+    #[QueryMethod]
+    public function getHistory(): array;
+}

--- a/projects/espace/api/poc/temporal/worker.php
+++ b/projects/espace/api/poc/temporal/worker.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Poc\Temporal\AreaProposalActivities;
+use App\Poc\Temporal\AreaProposalWorkflow;
+use Temporal\WorkerFactory;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+/**
+ * RoadRunner worker host. RoadRunner (configured in .rr.yml) boots this script
+ * as one or more PHP processes and streams workflow/activity tasks to it over
+ * gRPC. This is the equivalent of `messenger:consume` for Temporal.
+ */
+$factory = WorkerFactory::create();
+
+$worker = $factory->newWorker('espace.area_proposal');
+
+$worker->registerWorkflowTypes(AreaProposalWorkflow::class);
+$worker->registerActivity(AreaProposalActivities::class);
+
+$factory->run();


### PR DESCRIPTION
## Context

POC: orchestrate an espace API workflow with **Temporal** instead of the **Symfony Workflow** component, plus a written analysis of whether it's an improvement.

The chosen real-world case is the `AreaProposal` (_landProposal_) publishing lifecycle, which already has a Symfony state machine (`area_proposal_publishing`) in `projects/espace/api/src/Workflow/AreaProposal/`, making it a clean 1:1 comparison.

## What's in here

Everything lives under `projects/espace/api/poc/temporal/`, fully **isolated** from the api project (its own `composer.json` / `compose.yml`, outside the phpstan & rector scopes — so it does not affect the espace-api build or lint).

- **`ANALYSIS.md`** — the core deliverable: Symfony Workflow vs Temporal comparison and a recommendation.
- **`src/AreaProposalWorkflow*.php`** — the durable Temporal workflow mirroring the exact same state machine:
  ```
  draft ──submit──▶ verification ──publish──▶ published ──archive──▶ archived
                    verification ──reject───▶ draft
  ```
  driven by signals (`submit` / `publish` / `reject` / `archive`) with a `getPlace` / `getHistory` query.
- **`src/AreaProposalActivities*.php`** — side effects (DB persist, notifications, SEO (de)indexing) as retried Temporal Activities.
- **`worker.php`, `bin/*.php`, `.rr.yml`, `compose.yml`, `Dockerfile`** — RoadRunner worker, client scripts to start/drive a workflow, and a self-contained Temporal server + UI stack.

Two capabilities go beyond the Symfony version to show what Temporal buys you: **automatic retries** on every side effect, and a **durable timer** that auto-archives a long-published proposal without any cron/Messenger.

## Recommendation (see ANALYSIS.md)

**Keep Symfony Workflow** for the current short, HTTP-driven state machines — Temporal's infrastructure cost (a Temporal cluster + a second PHP runtime, RoadRunner, alongside FrankenPHP) isn't justified for simple status transitions. **Reconsider Temporal** only when a genuinely long, distributed process appears (e.g. an end-to-end `landRequest ↔ landProposal` matching flow with waits, reminders, expirations and faillible external calls). This POC is the groundwork for that future evaluation.

## Notes

- POC was not executed end-to-end in CI (it needs a running Temporal server + the `grpc`/`protobuf` PHP extensions + RoadRunner, all provided via the included `Dockerfile`/`compose.yml`). All PHP files pass `php -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tDR7rUFU2x6QMDptVYRam

---
_Generated by [Claude Code](https://claude.ai/code/session_018tDR7rUFU2x6QMDptVYRam)_