### PR TITLE
chore(deps): bump moon, npm, and eslint tooling to latest versions

### DIFF
--- a/.prototools
+++ b/.prototools
@@ -1,7 +1,7 @@
-moon = "2.3.5"
+moon = "2.4.0"
 node = "24.18.0"
 yarn = "4.17.0"
-npm = "11.17.0"
+npm = "11.18.0"
 
 [settings]
 auto-install = true

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@eslint/markdown": "^8.0.2",
+    "@eslint/markdown": "^8.0.3",
     "@types/eslint": "^9.6.1",
     "@types/node": "^26.0.1",
     "eslint": "^10.6.0",
@@ -13,7 +13,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-tailwindcss": "^4.0.4",
-    "eslint-plugin-unicorn": "^69.0.0",
+    "eslint-plugin-unicorn": "^70.0.0",
     "eslint-plugin-vue": "^10.9.2",
     "eslint-plugin-yml": "^3.5.0",
     "globals": "^17.7.0",


### PR DESCRIPTION
## Summary

Routine dependency audit across `.prototools` and all `package.json` files in the monorepo (composer/PHP deps excluded per request). All 92 unique npm dependencies declared across the 58 `package.json` files were checked against the npm registry. The repo was already largely up to date thanks to the recent #202 bump — only 4 packages were behind.

---

## Proto Toolchain (`.prototools`)

| Tool | Current | Latest | Type |
|------|---------|--------|------|
| moon | 2.3.5 | **2.4.0** | minor |
| node | 24.18.0 | 24.18.0 | ✅ up to date |
| yarn | 4.17.0 | 4.17.0 | ✅ up to date |
| npm | 11.17.0 | **11.18.0** | minor |

⚠️ Note: `moon` 2.4.0 was published to npm the same day as this audit (2026-07-05), so it is a very fresh release. Worth a quick look at the [moon changelog](https://github.com/moonrepo/moon/releases) before merging, or holding this one line back a few days if you'd rather not be on the bleeding edge.

---

## npm Dependencies

### ⚠️ Major (breaking changes possible — reviewed, no issues found)

| Package | Current | Latest | Files |
|---------|---------|--------|-------|
| `eslint-plugin-unicorn` | ^69.0.0 | **^70.0.0** | root `package.json` |

Verified locally against several representative projects (`projects/website`, `projects/tera/app`, `projects/tera/website`, and root `README.md`) — no new lint errors surfaced.

### Patch (backwards-compatible bug fixes)

| Package | Current | Latest | Files |
|---------|---------|--------|-------|
| `@eslint/markdown` | ^8.0.2 | **^8.0.3** | root `package.json` |

All other 90 direct dependencies across the workspace are already at the latest version permitted by their declared range.

---

## Security Advisories

`yarn npm audit --recursive` was run against a fresh install and found **25 advisories** (16 high, 7 moderate, 2 low): `flatted`, `glob`, `minimatch`, `picomatch`, `ip-address`, and `tar`. All of them sit several levels deep in the dev-tooling dependency graph (transitive deps of `node-gyp`, `eslint-plugin-import@2.32.0`, and `micromatch`) — none are reachable by bumping a directly-declared `package.json` entry, since the packages that pull them in either have no newer release yet or the fix requires a `resolutions`/override entry. Flagging here rather than silently fixing, since forcing transitive overrides is a bigger, separate change that deserves its own review.

GitHub also reports **73 Dependabot advisories** on `main` (33 high, 34 moderate, 6 low) — pre-existing and out of scope for this PR (same note as in #202).

---

## Also noticed (not fixed here, flagging for awareness)

`yarn.lock` has drifted out of sync with the ranges declared in `package.json` for several packages (e.g. `vue` is declared as `^3.5.39` but the lockfile still resolves it against an older `^3.5.35` range) — this is a side effect of prior dependency-bump PRs (#178, #199, #202) only touching `package.json`/`.prototools` without regenerating `yarn.lock`. It isn't breaking anything today because `enableImmutableInstalls: false` lets installs silently re-resolve, but it means the checked-in lockfile doesn't reflect what actually gets installed. Regenerating it produces a ~2,500 line diff unrelated to this PR's scope, so it's called out here rather than bundled in — happy to do it as a dedicated follow-up if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kuHrtLhTGMvkABbMxhLHG


---
_Generated by [Claude Code](https://claude.ai/code/session_012kuHrtLhTGMvkABbMxhLHG)_